### PR TITLE
docs: add ShackSwitch, VfoWidget and missing pages from catalog rebuild

### DIFF
--- a/docs/features/client-eq/adjust-post-eq-output-gain-with-the-output-fader.md
+++ b/docs/features/client-eq/adjust-post-eq-output-gain-with-the-output-fader.md
@@ -1,0 +1,43 @@
+# Adjust post-EQ output gain with the Output Fader
+
+The Output Fader sets a master gain applied after all EQ bands on either the TX or RX path. Use it to compensate for overall level changes introduced by your EQ curve without touching individual band gains.
+
+## Before you start
+
+- The floating editor (titled "Aetherial Parametric EQ — TX" or "Aetherial Parametric EQ — RX") must be open. The Output Fader is not present in the docked applet tile.
+- The matching EQ stage must be enabled. See [Bypass the EQ stage from the chain](bypass-the-eq-stage-from-the-chain.md) if the stage is currently bypassed.
+
+## Steps
+
+1. Open the floating editor for the path you want to adjust. Double-click the EQ stage in the CHAIN widget on the TX or RX side.
+2. Locate the Output Fader on the right edge of the editor window. It is a vertical combined fader and level meter.
+3. Drag the fader handle up or down to set the post-EQ master gain. The valid range is -36.0 to +12.0 dB.
+4. To make a fine adjustment, hover over the fader and scroll the mouse wheel. Each scroll step moves the gain by 0.5 dB.
+5. To return the gain to the default, double-click the fader handle. This resets the value to 0 dB.
+
+## What each control does
+
+| Control | Default | Valid range | Persisted setting |
+|---|---|---|---|
+| Output Fader (TX path) | 0 dB | -36.0 to +12.0 dB | `ClientEqTxMasterGain` |
+| Output Fader (RX path) | 0 dB | -36.0 to +12.0 dB | `ClientEqRxMasterGain` |
+
+The level bar behind the fader handle shows the smoothed post-EQ peak level in real time, using the same green-amber-red gradient as the Tube level meter. This is a display indicator only; it does not respond to dragging.
+
+## Tips
+
+- Use the live level bar on the Output Fader to confirm that your EQ changes have not pushed the output into the red before transmitting or routing audio further.
+- The TX and RX Output Faders are independent. Adjusting one path does not affect the other.
+- The gain value is persisted immediately. If you close and reopen the editor, the fader returns to the last saved position.
+
+## Troubleshooting
+
+- **Output Fader is not visible** — The fader is only present in the floating editor, not in the docked "Aetherial TX EQ" or "Aetherial RX EQ" applet tile. Open the floating editor by double-clicking the EQ stage in the CHAIN widget.
+- **Double-click does not reset the fader** — Ensure you are double-clicking directly on the fader handle, not on the level bar area behind it.
+
+## Related
+
+- [Monitor post-EQ peak level on the Output Fader meter](monitor-post-eq-peak-level-on-the-output-fader-meter.md)
+- [Open the frameless editor to add / remove / tune bands on either side](open-the-frameless-editor-to-add-remove-tune-bands-on-either-side.md)
+- [Bypass the EQ stage from the chain](bypass-the-eq-stage-from-the-chain.md)
+- [Aetherial Parametric EQ (TX / RX) overview](overview.md)

--- a/docs/features/client-eq/change-a-band-s-filter-type-by-clicking-its-icon-in-the-icon-row.md
+++ b/docs/features/client-eq/change-a-band-s-filter-type-by-clicking-its-icon-in-the-icon-row.md
@@ -1,0 +1,40 @@
+# Change a band's filter type by clicking its icon in the icon row
+
+Each band in the Aetherial Parametric EQ has a filter type (peak bell, shelf, HP slope, LP slope) shown as a small icon above the EQ canvas. Clicking an icon cycles that band to the next filter type without opening any additional dialog.
+
+## Before you start
+
+- The floating editor must be open. The icon row is only available in the "Aetherial Parametric EQ — TX" or "Aetherial Parametric EQ — RX" frameless editor window, not in the docked applet tile.
+- If the editor is not open, double-click the EQ stage in the CHAIN widget on the TX or RX side to open it. See [Open the frameless editor to add / remove / tune bands on either side](open-the-frameless-editor-to-add-remove-tune-bands-on-either-side.md).
+
+## Steps
+
+1. Open the floating editor for the TX or RX side as needed.
+2. Locate the filter-type icon row at the top of the editor canvas area. There is one icon per band slot (up to 8 icons), each drawn in that band's palette colour showing its current filter shape.
+3. Click the icon for the band whose filter type you want to change. Clicking cycles that band to the next filter type and simultaneously selects the band — its handle on the canvas is highlighted and its column in the parameter text row at the bottom is highlighted.
+4. Continue clicking the same icon to cycle through the remaining filter types until the desired type is shown.
+
+## What each control does
+
+| Control | Behavior | Default | Setting key |
+|---|---|---|---|
+| Filter-type icon row | A row of up to 8 icons at the top of the editor canvas. Each icon draws the current filter shape for its band in that band's palette colour. Click to cycle the filter type; clicking also selects the band. Icons dim to 35% opacity when the band is bypassed. | — | — |
+| Parameter text row | A row of up to 8 text columns below the canvas showing each band's Freq, Gain, and Q values. Updates live during canvas drags. Clicking a column selects that band. | — | — |
+
+## Tips
+
+- The hint text in the editor header strip reads "click icon to cycle type" — this is the only action the icon row supports; there is no right-click menu on individual icons.
+- If an icon appears dimmed (35% opacity), that band is bypassed. Its filter type can still be cycled, but the band will have no effect on the EQ curve until it is re-enabled.
+- The filter family selected in the Filter family combo (default: Butterworth) governs HP and LP cascade mathematics. Changing a band to an HP or LP type will use the currently selected family. Peak and shelf bands use their own fixed 2nd-order topology regardless of the Filter family setting.
+
+## Troubleshooting
+
+- **The icon row is not visible** — The icon row is only present in the floating editor, not in the docked "Aetherial TX EQ" or "Aetherial RX EQ" applet tile. Open the floating editor by double-clicking the EQ stage in the CHAIN widget.
+- **Clicking an icon has no effect on the EQ curve** — The band may be bypassed (icon is dimmed to 35% opacity). Re-enable the band to hear the filter type change reflected in the summed curve.
+
+## Related
+
+- [Open the frameless editor to add / remove / tune bands on either side](open-the-frameless-editor-to-add-remove-tune-bands-on-either-side.md)
+- [Change the HP/LP filter family (Butterworth, Chebyshev, Bessel, Elliptic)](change-the-hp-lp-filter-family-butterworth-chebyshev-bessel-elliptic.md)
+- [Read exact freq / gain / Q values in the parameter text row](read-exact-freq-gain-q-values-in-the-parameter-text-row.md)
+- [Aetherial Parametric EQ (TX / RX) overview](overview.md)

--- a/docs/features/client-eq/change-the-hp-lp-filter-family-butterworth-chebyshev-bessel-elliptic.md
+++ b/docs/features/client-eq/change-the-hp-lp-filter-family-butterworth-chebyshev-bessel-elliptic.md
@@ -1,0 +1,54 @@
+# Change the HP/LP filter family (Butterworth, Chebyshev, Bessel, Elliptic)
+
+The **Filter family** selector controls the mathematics used for HP and LP filter bands in the client EQ. Changing it lets you trade off rolloff steepness, passband flatness, and phase linearity to suit your audio goals.
+
+## Before you start
+
+- The EQ stage for the path you want to change (TX or RX) must be enabled. See [Bypass the EQ stage from the chain](bypass-the-eq-stage-from-the-chain.md).
+- The floating editor must be open. The **Filter family** selector is only available in the frameless editor, not the docked applet tile. See [Open the frameless editor to add / remove / tune bands on either side](open-the-frameless-editor-to-add-remove-tune-bands-on-either-side.md).
+- At least one band must be set to an HP or LP filter type. The setting has no audible effect if only peak and shelf bands are present.
+
+## Steps
+
+1. Open the floating editor for the path you want to change — double-click the EQ stage in the CHAIN widget on the TX or RX side. The window title will read "Aetherial Parametric EQ — TX" or "Aetherial Parametric EQ — RX".
+2. Locate the **Filter family** combo box in the editor header strip, to the right of the **Peak Hold** button.
+3. Click the combo box and select one of the four options: **Butterworth**, **Chebyshev**, **Bessel**, or **Elliptic**.
+4. The EQ curve on the canvas updates immediately. If HP or LP bands are present, their slopes will redraw to reflect the new family.
+
+The selection is saved automatically. It is stored separately for each path: `ClientEqTxFilterFamily` for the TX editor and `ClientEqRxFilterFamily` for the RX editor.
+
+## What each control does
+
+| Control | Default | Valid values | Setting key |
+|---|---|---|---|
+| **Filter family** (TX editor) | Butterworth | Butterworth, Chebyshev, Bessel, Elliptic | `ClientEqTxFilterFamily` |
+| **Filter family** (RX editor) | Butterworth | Butterworth, Chebyshev, Bessel, Elliptic | `ClientEqRxFilterFamily` |
+
+**Butterworth** — maximally flat passband; no ripple in the passband or stopband. The default choice for general use.
+
+**Chebyshev** — steeper transition band than Butterworth, with 1 dB of ripple in the passband.
+
+**Bessel** — linear phase response and the gentlest rolloff of the four families. Preserves transient shape.
+
+**Elliptic** — steepest transition of all four options, with ripple in both the passband and the stopband.
+
+These options apply only to HP and LP band types. Peak and shelf bands use their own fixed second-order topology regardless of this setting.
+
+## Tips
+
+- If you have no HP or LP bands in the current EQ, switching the filter family changes nothing audible. Add an HP or LP band first via the filter-type icon row.
+- The filter family is set independently for TX and RX. Changing it in the TX editor does not affect the RX editor, and vice versa.
+- Clicking **Reset** in the editor header strip resets the filter family back to **Butterworth** along with all band parameters.
+
+## Troubleshooting
+
+- **The Filter family combo is not visible** — The combo is only present in the floating editor, not the docked applet tile. Double-click the EQ stage in the CHAIN widget to open the editor.
+- **Changing the family has no effect on the curve** — No HP or LP bands are active. The setting only affects HP and LP cascade math. Check each band's type using the filter-type icon row.
+
+## Related
+
+- [Open the frameless editor to add / remove / tune bands on either side](open-the-frameless-editor-to-add-remove-tune-bands-on-either-side.md)
+- [Change a band's filter type by clicking its icon in the icon row](change-a-band-s-filter-type-by-clicking-its-icon-in-the-icon-row.md)
+- [Reset all EQ bands to the default 10-band template](reset-all-eq-bands-to-the-default-10-band-template.md)
+- [Bypass the EQ stage from the chain](bypass-the-eq-stage-from-the-chain.md)
+- [Aetherial Parametric EQ (TX / RX) overview](overview.md)

--- a/docs/features/client-eq/drag-the-tx-or-rx-filter-cutoff-guide-line-to-move-the-radio-passband.md
+++ b/docs/features/client-eq/drag-the-tx-or-rx-filter-cutoff-guide-line-to-move-the-radio-passband.md
@@ -1,0 +1,43 @@
+# Drag the TX or RX filter cutoff guide line to move the radio passband
+
+The EQ editor canvas shows dashed yellow vertical lines at the radio's current TX or RX filter cutoff edges. Dragging these lines moves the radio's passband in real time, letting you match your EQ shaping to the actual filter boundaries without leaving the EQ editor.
+
+## Before you start
+
+- AetherSDR must be connected to the radio.
+- The floating editor for the relevant side (TX or RX) must be open. The guide lines are draggable only in the frameless editor canvas, not in the docked applet tile.
+- To open the floating editor, double-click the EQ stage in the CHAIN widget on the TX or RX side. See [Open the frameless editor to add / remove / tune bands on either side](open-the-frameless-editor-to-add-remove-tune-bands-on-either-side.md).
+
+## Steps
+
+1. Open the floating editor for the side you want to adjust: double-click the EQ stage in the CHAIN widget. The editor title bar reads "Aetherial Parametric EQ — TX" or "Aetherial Parametric EQ — RX".
+2. Locate the dashed yellow vertical lines on the canvas. There are two: one at the low cutoff edge and one at the high cutoff edge of the radio's current passband.
+3. Move the pointer toward one of the dashed yellow lines. When the pointer is close enough to the line, the cursor changes to a horizontal-resize arrow.
+4. Click and drag the line left or right. The radio's corresponding filter cutoff updates in real time as you drag.
+5. Release to set the new cutoff position.
+6. Repeat for the other guide line if you want to adjust the opposite passband edge.
+
+## What each control does
+
+| Control | Behavior | Notes |
+|---|---|---|
+| Filter cutoff guide lines (TX) | Dashed yellow vertical lines on the TX editor canvas marking the radio's current TX low and high filter cutoffs. Drag in the editor to move the radio's TX passband in real time. | Cursor changes to a horizontal-resize arrow when hovering near a line. |
+| Filter cutoff guide lines (RX) | Dashed yellow vertical lines on the RX editor canvas marking the active slice's RX passband edges (in the audio-frequency domain). Drag in the editor to move the radio's RX passband in real time. | Cursor changes to a horizontal-resize arrow when hovering near a line. |
+
+## Tips
+
+- The guide lines are visible in both the docked applet tile and the floating editor, but dragging is only active in the floating editor canvas.
+- A guide line is absent when the corresponding cutoff value is 0 or not set by the radio.
+- Watch the parameter text row at the bottom of the editor while dragging to confirm the resulting passband edges.
+
+## Troubleshooting
+
+- **Cursor does not change to a horizontal-resize arrow near the line** — You are hovering over the docked applet tile, not the floating editor canvas. Open the floating editor by double-clicking the EQ stage in the CHAIN widget, then try again.
+- **No dashed yellow lines are visible on the canvas** — The radio has not reported filter cutoff values, or both cutoff values are 0. Verify the radio is connected and a slice is active.
+
+## Related
+
+- [Open the frameless editor to add / remove / tune bands on either side](open-the-frameless-editor-to-add-remove-tune-bands-on-either-side.md)
+- [Inspect the TX EQ curve and live spectrum](inspect-the-tx-eq-curve-and-live-spectrum.md)
+- [Inspect the RX EQ curve and live spectrum](inspect-the-rx-eq-curve-and-live-spectrum.md)
+- [Read exact freq / gain / Q values in the parameter text row](read-exact-freq-gain-q-values-in-the-parameter-text-row.md)

--- a/docs/features/client-eq/freeze-the-analyzer-peak-hold-trace-to-spot-resonances-while-tuning.md
+++ b/docs/features/client-eq/freeze-the-analyzer-peak-hold-trace-to-spot-resonances-while-tuning.md
@@ -1,0 +1,42 @@
+# Freeze the analyzer peak-hold trace to spot resonances while tuning
+
+The peak-hold trace marks the highest energy level observed at each frequency since the last reset. Freezing it stops the normal ~10 dB/sec decay so the trace stays stationary while you adjust EQ bands or passband edges — making it easier to identify resonances and harsh peaks.
+
+## Before you start
+
+- Open the floating editor for the TX or RX EQ side. The `Peak Hold` button is in the editor header strip only — it is not available on the docked applet tile. See [Open the frameless editor to add / remove / tune bands on either side](open-the-frameless-editor-to-add-remove-tune-bands-on-either-side.md).
+- Ensure audio is passing through the EQ path so the live FFT analyzer is active and the peak-hold trace is accumulating data.
+
+## Steps
+
+1. Open the floating editor for the side you want to inspect (TX or RX) by double-clicking the EQ stage in the CHAIN widget.
+2. Let audio run for a few seconds so the peak-hold trace builds up across the frequency range.
+3. Click `Peak Hold` in the editor header strip. The button turns amber to confirm it is checked.
+4. Adjust your EQ bands, filter cutoffs, or other settings while reading the frozen trace. The trace remains stationary regardless of current signal level.
+5. Click `Peak Hold` again to uncheck it. The trace resumes normal decay (~10 dB/sec).
+
+## What each control does
+
+| Control | Location | Default | Behavior | Persisted key |
+|---|---|---|---|---|
+| `Peak Hold` | Editor header strip | Unchecked | When checked, freezes the per-bin peak-hold trace at the highest level observed at each frequency. No decay occurs until toggled off. Amber background when checked. | — (not persisted) |
+| `Smoothing` | Editor header strip | `Off (1/96)` | Fractional-octave power-averaging applied to the analyzer display only. Options: `Off (1/96)`, `1/24`, `1/12`, `1/6`, `1/3`. Lower fraction = smoother. Does not affect the peak-hold trace bins or EQ math. | `ClientEqSmoothingFraction` |
+
+## Tips
+
+- The peak-hold trace tracks raw frequency bins even when display smoothing (`Smoothing` combo) is set to a coarse value such as `1/3`. If a resonance appears in the frozen trace but looks rounded at a coarse smoothing setting, switch `Smoothing` to `Off (1/96)` to see the full bin-level detail.
+- To clear the accumulated peak data without toggling `Peak Hold` off and on, uncheck then immediately recheck the button after a moment of silence or reduced signal.
+- The dashed yellow filter cutoff guide lines remain draggable while `Peak Hold` is active. This lets you align the radio passband edges directly to features visible on the frozen trace.
+
+## Troubleshooting
+
+- **`Peak Hold` button is not visible** — The button is in the floating editor only, not in the docked `Aetherial TX EQ` or `Aetherial RX EQ` applet tile. Open the floating editor by double-clicking the EQ stage in the CHAIN widget.
+- **Trace decays immediately after clicking `Peak Hold`** — Confirm the button shows an amber background, which indicates it is checked. A single click that registers as a double-click may toggle the button back off. Click once firmly and verify the amber state.
+
+## Related
+
+- [Open the frameless editor to add / remove / tune bands on either side](open-the-frameless-editor-to-add-remove-tune-bands-on-either-side.md)
+- [Smooth the analyzer display for easier reading with the Smoothing combo](smooth-the-analyzer-display-for-easier-reading-with-the-smoothing-combo.md)
+- [Drag the TX or RX filter cutoff guide line to move the radio passband](drag-the-tx-or-rx-filter-cutoff-guide-line-to-move-the-radio-passband.md)
+- [Inspect the TX EQ curve and live spectrum](inspect-the-tx-eq-curve-and-live-spectrum.md)
+- [Inspect the RX EQ curve and live spectrum](inspect-the-rx-eq-curve-and-live-spectrum.md)

--- a/docs/features/client-eq/monitor-post-eq-peak-level-on-the-output-fader-meter.md
+++ b/docs/features/client-eq/monitor-post-eq-peak-level-on-the-output-fader-meter.md
@@ -1,0 +1,37 @@
+# Monitor post-EQ peak level on the Output Fader meter
+
+The Output Fader in the floating EQ editor displays a live post-EQ peak level meter behind its handle, letting you see how much headroom remains after your EQ curve and master gain setting are applied.
+
+## Before you start
+
+- The floating EQ editor must be open for the path you want to monitor (TX or RX). The Output Fader is not present in the docked applet tile.
+- The EQ stage should be enabled. If the stage is bypassed, the meter still reflects the signal passing through, but the EQ curve has no effect.
+
+## Steps
+
+1. Open the floating editor for the path you want to monitor. Double-click the matching EQ stage in the CHAIN widget — either the TX or RX side — to open the editor titled "Aetherial Parametric EQ — TX" or "Aetherial Parametric EQ — RX".
+2. Locate the Output Fader on the right edge of the floating editor. It is a vertical combined fader and level meter.
+3. Observe the level bar behind the fader handle. The bar displays the smoothed post-EQ peak level in real time using a green-amber-red gradient, the same as the Tube level meter.
+4. Transmit or receive audio as normal. The level bar updates continuously, reflecting the signal level after all EQ bands and the master gain offset have been applied.
+
+## What each control does
+
+| Control | Default | Valid range | Persisted key |
+|---|---|---|---|
+| Output Fader (TX) | 0 dB | −36.0 to +12.0 dB | `ClientEqTxMasterGain` |
+| Output Fader (RX) | 0 dB | −36.0 to +12.0 dB | `ClientEqRxMasterGain` |
+
+The level meter behind the fader handle is an indicator only. It shows the smoothed post-EQ peak for the path bound to this editor instance. It does not have a separate control or persisted key.
+
+## Tips
+
+- If the meter is consistently hitting amber or red, drag the Output Fader handle down to reduce post-EQ gain, or reduce individual band gains to bring levels down before the master stage.
+- Scroll the mouse wheel over the Output Fader for fine 0.5 dB adjustments while watching the meter.
+- Double-click the Output Fader to reset it to 0 dB without disturbing your band settings.
+
+## Related
+
+- [Adjust post-EQ output gain with the Output Fader](adjust-post-eq-output-gain-with-the-output-fader.md)
+- [Open the frameless editor to add / remove / tune bands on either side](open-the-frameless-editor-to-add-remove-tune-bands-on-either-side.md)
+- [Freeze the analyzer peak-hold trace to spot resonances while tuning](freeze-the-analyzer-peak-hold-trace-to-spot-resonances-while-tuning.md)
+- [Bypass the EQ stage from the chain](bypass-the-eq-stage-from-the-chain.md)

--- a/docs/features/client-eq/read-exact-freq-gain-q-values-in-the-parameter-text-row.md
+++ b/docs/features/client-eq/read-exact-freq-gain-q-values-in-the-parameter-text-row.md
@@ -1,0 +1,34 @@
+# Read exact freq / gain / Q values in the parameter text row
+
+The parameter text row shows the precise frequency, gain, and Q value for every EQ band in a single glance. Use it to confirm exact settings after dragging bands on the canvas, or to identify which band is selected before making adjustments.
+
+## Before you start
+
+- The parameter text row is only visible in the floating ClientEqEditor window, not in the docked applet tile. Open the editor first.
+- At least one EQ band must exist. The row shows one column per band slot, up to eight bands.
+
+## Steps
+
+1. Open the floating editor for the side you want to inspect. Double-click the EQ stage in the CHAIN widget on either the TX or RX side. The editor window is titled "Aetherial Parametric EQ — TX" or "Aetherial Parametric EQ — RX".
+2. Locate the parameter text row at the bottom of the editor canvas area. It displays one column per band, each showing that band's Freq, Gain, and Q values.
+3. Read the values directly. The row updates live as you drag band handles on the canvas — no extra action is needed.
+4. To read values for a specific band, click its column in the parameter text row. This selects that band, highlighting its handle on the canvas and its icon in the filter-type icon row above.
+
+## What each control does
+
+| Control | Behavior | Default | Setting key |
+|---|---|---|---|
+| Parameter text row | Displays Freq, Gain, and Q for each of the eight band slots. Updates live during canvas drags. Clicking a column selects that band. | — | — |
+| Filter-type icon row | Row of icons above the canvas, one per band slot. Clicking an icon selects that band and cycles its filter type. Selected band is highlighted in both the icon row and the parameter text row. | — | — |
+
+## Tips
+
+- Dragging a band handle on the canvas updates the parameter text row in real time, so you can watch the numeric values change while tuning by ear.
+- Clicking a column in the parameter text row is equivalent to clicking the matching icon in the filter-type icon row — both select the same band.
+- Bands that are bypassed show dimmed icons (35% opacity) in the icon row above; their values still appear in the parameter text row.
+
+## Related
+
+- [Open the frameless editor to add / remove / tune bands on either side](open-the-frameless-editor-to-add-remove-tune-bands-on-either-side.md)
+- [Change a band's filter type by clicking its icon in the icon row](change-a-band-s-filter-type-by-clicking-its-icon-in-the-icon-row.md)
+- [Verify the summed curve matches your mental target](verify-the-summed-curve-matches-your-mental-target.md)

--- a/docs/features/client-eq/reset-all-eq-bands-to-the-default-10-band-template.md
+++ b/docs/features/client-eq/reset-all-eq-bands-to-the-default-10-band-template.md
@@ -1,0 +1,34 @@
+# Reset all EQ bands to the default 10-band template
+
+Use this procedure to discard all EQ band edits for a TX or RX equalizer and return it to the factory 10-band configuration. This also resets the band count and filter family to their defaults.
+
+## Before you start
+
+- The floating editor for the EQ path you want to reset (TX or RX) must be open. See [Open the frameless editor to add / remove / tune bands on either side](open-the-frameless-editor-to-add-remove-tune-bands-on-either-side.md) if it is not already open.
+
+## Steps
+
+1. In the floating editor title bar, confirm you are on the correct path — the window title reads either "Aetherial Parametric EQ — TX" or "Aetherial Parametric EQ — RX".
+2. Click Reset in the editor header strip.
+
+All bands are immediately replaced with the default 10-band template. The band count is restored to 10, and the Filter family combo is reset to Butterworth. The settings are saved immediately.
+
+## What each control does
+
+| Control | Default | Behavior after reset |
+|---|---|---|
+| Reset | — | Replaces all bands with the default 10-band template, restores the default band count, and sets Filter family to Butterworth. Saves immediately. |
+| Filter family | Butterworth | Reset to Butterworth. Applies to HP and LP filter types only; peak and shelf bands are unaffected by this selector. Persisted as `ClientEqTxFilterFamily` (TX) or `ClientEqRxFilterFamily` (RX). |
+| Band count | 10 | Restored to 10 by Reset. Persisted as `ClientEqTxBandCount` (TX) or `ClientEqRxBandCount` (RX). |
+
+## Tips
+
+- Reset affects only the path shown in the current editor window. To reset the other path, open the other editor and repeat.
+- The Output Fader (post-EQ master gain, persisted as `ClientEqTxMasterGain` or `ClientEqRxMasterGain`) is not changed by Reset. Double-click the fader to return it to 0 dB separately if needed.
+
+## Related
+
+- [Open the frameless editor to add / remove / tune bands on either side](open-the-frameless-editor-to-add-remove-tune-bands-on-either-side.md)
+- [Change the HP/LP filter family (Butterworth, Chebyshev, Bessel, Elliptic)](change-the-hp-lp-filter-family-butterworth-chebyshev-bessel-elliptic.md)
+- [Adjust post-EQ output gain with the Output Fader](adjust-post-eq-output-gain-with-the-output-fader.md)
+- [Change a band's filter type by clicking its icon in the icon row](change-a-band-s-filter-type-by-clicking-its-icon-in-the-icon-row.md)

--- a/docs/features/client-eq/smooth-the-analyzer-display-for-easier-reading-with-the-smoothing-combo.md
+++ b/docs/features/client-eq/smooth-the-analyzer-display-for-easier-reading-with-the-smoothing-combo.md
@@ -1,0 +1,46 @@
+# Smooth the analyzer display for easier reading with the Smoothing combo
+
+The Smoothing combo applies fractional-octave power-averaging to the live FFT analyzer trace in the Aetherial Parametric EQ editor. Use it to reduce trace jitter and make broad response trends easier to read while tuning. The setting affects display only — EQ math is unchanged.
+
+## Before you start
+
+- The floating editor must be open. Double-click the EQ stage in the CHAIN widget (TX or RX side) to open it. The editor is titled "Aetherial Parametric EQ — TX" or "Aetherial Parametric EQ — RX".
+- The Smoothing combo is in the editor header strip. It is not available in the docked applet tile.
+
+## Steps
+
+1. Open the floating editor for either the TX or RX EQ stage by double-clicking the matching EQ stage in the CHAIN widget.
+2. Locate the "Smoothing:" label in the editor header strip.
+3. Click the combo box to the right of the "Smoothing:" label.
+4. Select a smoothing level from the list:
+   - `Off (1/96)` — effectively no smoothing (default)
+   - `1/24` — light smoothing
+   - `1/12` — moderate smoothing
+   - `1/6` — heavier smoothing
+   - `1/3` — most smoothed
+5. The analyzer trace updates immediately.
+
+## What each control does
+
+| Control | Default | Valid values | Persisted setting |
+|---|---|---|---|
+| Smoothing | `Off (1/96)` | `Off (1/96)` / `1/24` / `1/12` / `1/6` / `1/3` | `ClientEqSmoothingFraction` |
+
+**Smoothing** — Applies fractional-octave power-averaging to the analyzer trace. Lower fraction values produce a smoother trace: `1/3` is the most smoothed; `Off (1/96)` is effectively unsmoothed. The setting is shared between the TX and RX editors — changing it in one editor also affects the other. EQ math and the peak-hold trace are not affected.
+
+## Tips
+
+- The peak-hold trace tracks raw bins regardless of the smoothing setting. If you want to see both the smoothed trend and the raw peaks simultaneously, enable Peak Hold while smoothing is active.
+- `1/6` or `1/3` smoothing is useful for comparing your EQ curve against the broad shape of the analyzer fill without fine bin-level noise obscuring the comparison.
+
+## Troubleshooting
+
+- **Smoothing combo is not visible** — The combo is only present in the floating editor, not in the docked "Aetherial TX EQ" or "Aetherial RX EQ" applet tile. Open the editor by double-clicking the EQ stage in the CHAIN widget.
+- **Changing smoothing in the TX editor also changes the RX editor** — This is expected. `ClientEqSmoothingFraction` is a single global preference shared between both editors.
+
+## Related
+
+- [Freeze the analyzer peak-hold trace to spot resonances while tuning](freeze-the-analyzer-peak-hold-trace-to-spot-resonances-while-tuning.md)
+- [Open the frameless editor to add / remove / tune bands on either side](open-the-frameless-editor-to-add-remove-tune-bands-on-either-side.md)
+- [Inspect the TX EQ curve and live spectrum](inspect-the-tx-eq-curve-and-live-spectrum.md)
+- [Inspect the RX EQ curve and live spectrum](inspect-the-rx-eq-curve-and-live-spectrum.md)

--- a/docs/features/client-gate/set-return-to-prevent-gate-chatter-near-threshold.md
+++ b/docs/features/client-gate/set-return-to-prevent-gate-chatter-near-threshold.md
@@ -1,0 +1,46 @@
+# Set Return to prevent gate chatter near threshold
+
+When audio levels hover near the threshold, the gate can open and close rapidly, producing an audible stuttering effect called chatter. The Return knob adds a hysteresis deadband so the gate does not close again until the signal drops a set amount below the threshold where it opened.
+
+## Before you start
+
+- The gate must be enabled on the TX or RX side. See [Bypass the gate from the chain](bypass-the-gate-from-the-chain.md) to confirm the gate stage is active.
+- Set Thresh first so you have a stable reference point. See [Set TX threshold just above room noise floor](set-tx-threshold-just-above-room-noise-floor.md).
+
+## Steps
+
+1. Open the **Aetherial TX Gate** sub-container (TX side) or the **Aetherial AGC-T** sub-container (RX side) inside the Aetherial Audio (TXDSP) parent container. Alternatively, double-click the GATE stage in the CHAIN widget to open the floating editor titled **Aetherial Gate — TX** or **Aetherial Gate — RX**.
+2. Locate the **Return** knob.
+3. Turn **Return** upward from its default of 2.00 dB until the chatter stops. Start with small increases — 3 to 5 dB is often sufficient for voice.
+4. Watch the transfer curve. A soft-cyan vertical band appears between (Thresh − Return) and Thresh, showing the hysteresis deadband. Widen or narrow it by adjusting **Return** until the band covers the range where your signal fluctuates.
+5. Speak or pass audio at a level that previously caused chatter. Confirm the gate opens cleanly and does not re-close until your level drops below the bottom edge of the cyan band.
+
+## What each control does
+
+| Control | Default | Valid range | Persisted key (TX / RX) |
+|---|---|---|---|
+| **Return** | 2.00 dB | 0.0 to 20.0 dB | `ClientGateTxReturnDb` / `ClientGateRxReturnDb` |
+| **Thresh** | −40.0 dB | −80.0 to 0.0 dB | `ClientGateTxThresholdDb` / `ClientGateRxThresholdDb` |
+
+**Return** sets the width of the hysteresis deadband in decibels. The gate opens when input rises above Thresh and does not close again until input falls below Thresh − Return. Setting Return to 0.0 dB removes the deadband entirely; the gate opens and closes at the same level, which maximises chatter risk near threshold.
+
+The transfer curve draws a soft-cyan vertical band between (Thresh − Return) and Thresh whenever Return is greater than 0.0 dB. This band is the gate's sticky zone — signals inside it leave the gate in whatever state it is already in.
+
+## Tips
+
+- If you raise Return so high that the gate stays open through long pauses in speech, reduce it in small steps (0.5 dB at a time) until pauses close the gate naturally.
+- Use the gain-reduction bar (amber strip, 0 to 40 dB scale) to confirm the gate is closing during true silence. If the bar never fills during a pause, Return may be too wide relative to your actual noise floor.
+- Changes to Return take effect immediately and are saved automatically. No restart is required.
+
+## Troubleshooting
+
+- **Chatter persists after increasing Return** — Thresh may be set too close to a noisy signal that fluctuates widely. Lower Thresh slightly so the gate opens only on clear speech, then re-tune Return.
+- **Gate stays open permanently** — Return is set wider than the gap between your signal level and the noise floor. Reduce Return until the gate closes reliably during silence.
+- **Cyan band is not visible on the transfer curve** — Return is set to 0.0 dB. Any value above 0.0 dB will render the band.
+
+## Related
+
+- [Set TX threshold just above room noise floor](set-tx-threshold-just-above-room-noise-floor.md)
+- [Tune release for natural gate close](tune-release-for-natural-gate-close.md)
+- [Watch live GR while not speaking](watch-live-gr-while-not-speaking.md)
+- [Choose gate vs soft-expander behaviour via ratio](choose-gate-vs-soft-expander-behaviour-via-ratio.md)

--- a/docs/features/client-gate/tune-release-for-natural-gate-close.md
+++ b/docs/features/client-gate/tune-release-for-natural-gate-close.md
@@ -1,0 +1,38 @@
+# Tune Release for Natural Gate Close
+
+The Release knob controls how quickly the gate closes after audio drops below the threshold. Setting it correctly prevents the gate from cutting off word endings too abruptly or leaving the gate open so long that background noise bleeds through between words.
+
+## Before you start
+
+- The gate stage must be enabled on the TX or RX side. See [Bypass the gate from the chain](bypass-the-gate-from-the-chain.md) if the gate is currently bypassed.
+- Open the Aetherial TX Gate or Aetherial AGC-T applet so the knobs are visible. The applet appears inside the Aetherial Audio (TXDSP) parent container once the gate stage is active.
+
+## Steps
+
+1. Locate the **Release** knob in the five-knob row at the bottom of the applet. It is the fourth knob from the left, between **Return** and **Floor**.
+2. Turn **Release** clockwise to increase the release time (slower close) or counter-clockwise to decrease it (faster close). The knob label updates live, showing the current value in milliseconds — formatted as `X.X ms` below 100 ms and `X ms` at 100 ms and above.
+3. Speak or pass audio through the gate while watching the gain-reduction bar. After audio drops below the threshold, observe how quickly the amber strip rises to full attenuation. Adjust **Release** until the gate closes smoothly without clipping word endings.
+4. If the gate closes so slowly that noise is audible between words, reduce **Release**. If word endings are cut off, increase **Release**.
+
+## What each control does
+
+| Control | Default | Valid range | Persisted key (TX / RX) |
+|---|---|---|---|
+| **Release** | 100 ms | 5 to 2000 ms | `ClientGateTxReleaseMs` / `ClientGateRxReleaseMs` |
+
+The knob uses an exponential mapping (5 × 400^n), so small movements at the low end of the range produce finer timing adjustments, while the upper range covers long, gradual fade-outs. Release begins only after the input has fallen below Thresh − Return; the **Return** value therefore affects when the release phase starts.
+
+## Tips
+
+- 100 ms (the default) suits most voice TX work. Increase toward 200–400 ms if consonants at the end of words are being clipped. Decrease toward 20–50 ms if background noise is audible in the gaps between words.
+- Release interacts with **Return**: a larger Return deadband delays the start of the release phase. If the gate seems to hang open, check **Return** before shortening **Release** further.
+- The gain-reduction bar updates approximately every 33 ms. Watch it in real time while adjusting **Release** to confirm the close speed before transmitting.
+- Changes take effect immediately and are saved automatically. No radio connection is required to adjust this setting.
+
+## Related
+
+- [Set Return to prevent gate chatter near threshold](set-return-to-prevent-gate-chatter-near-threshold.md)
+- [Set Floor to avoid unnatural silence between words](set-floor-to-avoid-unnatural-silence-between-words.md)
+- [Watch live GR while not speaking](watch-live-gr-while-not-speaking.md)
+- [Set TX threshold just above room noise floor](set-tx-threshold-just-above-room-noise-floor.md)
+- [Choose gate vs soft-expander behaviour via ratio](choose-gate-vs-soft-expander-behaviour-via-ratio.md)

--- a/docs/features/client-level-meter/overview.md
+++ b/docs/features/client-level-meter/overview.md
@@ -1,0 +1,40 @@
+# Output Level Meter overview
+
+The Output Level Meter is a vertical dB meter that shows the smoothed post-processing peak level of an audio stage. It gives you a continuous visual and numeric read of how close the output signal is to clipping, so you can set drive and output levels without guessing.
+
+## How it works
+
+The meter receives peak level updates from the audio engine and applies fast-attack / slow-release ballistics before displaying the result. When the incoming level rises, the smoothing factor is 0.6 (fast attack), so the bar reacts quickly to peaks. When the level falls, the smoothing factor is 0.08 (slow release), so the bar decays gradually. This matching ballistic behavior is shared with the EQ output fader meter, so all meters in AetherSDR feel visually consistent.
+
+The meter is visible inside the Tube applet's frameless editor, to the right of the saturation curve. Open it by double-clicking the TUBE stage in the chain widget. The same ballistics are also used by the EQ editor's Output Fader meter.
+
+No settings are persisted for this widget. It has no interactive controls; all elements are read-only indicators.
+
+## What each control does
+
+| Element | Description | Range / Values |
+|---|---|---|
+| Header label | Identifies what the meter is measuring. The Tube applet sets this to `OUT`. An empty string hides the header. | Any short string; default `OUT` |
+| Level bar | Gradient-filled vertical bar showing the smoothed peak level. Fills from the bottom up, proportional to the current dB value. | −60 dB (bottom) to 0 dB (top) |
+| dB scale ticks | Static reference grid to the left of the bar with labeled tick marks. | 0, −6, −12, −20, −40 dB |
+| Numeric readout | Displays the smoothed peak as a signed dB value to one decimal place, centered below the bar. Shows `-inf` when the level is below approximately −59.5 dB. | `-inf` or a value in the form `+/-XX.X dB` |
+
+### Level bar color
+
+The fill color changes with level to give an immediate sense of headroom:
+
+| Color | Level range | Meaning |
+|---|---|---|
+| Green | −60 dB to −12 dB | Normal operating level |
+| Lime | −12 dB to −6 dB | Moderate level |
+| Amber | −6 dB to −3 dB | Approaching clipping |
+| Red | Above −3 dB | 3 dB or less from clipping |
+
+## Tips
+
+- Watch for amber or red on the level bar while adjusting the Tube applet's Drive or Output knobs. Red means you have 3 dB or less of headroom before clipping.
+- The slow-release ballistics (alpha 0.08) mean the bar holds elevated readings briefly after a peak. This is intentional — it lets you catch transients that would otherwise disappear before you notice them.
+
+## Related
+
+- [Read the output level meter on the Tube applet](read-the-output-level-meter-on-the-tube-applet.md)

--- a/docs/features/client-level-meter/read-the-output-level-meter-on-the-tube-applet.md
+++ b/docs/features/client-level-meter/read-the-output-level-meter-on-the-tube-applet.md
@@ -1,0 +1,44 @@
+# Read the output level meter on the Tube applet
+
+The Output Level Meter in the Tube applet shows the smoothed post-saturation peak level of your audio signal. Use it to confirm that the Tube stage is not clipping its output and to judge how much headroom remains after drive and output gain are applied.
+
+## Before you start
+
+- The Tube applet must be present in the applet panel.
+- The Tube editor must be open. If it is not open, double-click the TUBE stage in the chain widget to open it.
+
+## Steps
+
+1. Double-click the TUBE stage in the chain widget to open the Tube editor.
+2. Locate the vertical meter on the right side of the editor, to the right of the saturation curve. The header label reads **OUT**.
+3. Feed audio through the radio. The level bar rises and falls as signal passes through the Tube stage.
+4. Read the color of the fill to judge headroom at a glance (see color meanings below).
+5. Read the numeric value in the readout below the bar for a precise signed dB figure.
+
+## What each control does
+
+| Element | What it shows | Range | Notes |
+|---|---|---|---|
+| Header label | Identifies the meter | Reads **OUT** | Confirms this meter shows the post-saturation output level. |
+| Level bar | Smoothed peak fill | −60 dB (bottom) to 0 dB (top) | Uses fast-attack (alpha = 0.6) / slow-release (alpha = 0.08) ballistics. |
+| dB scale ticks | Static reference grid | 0, −6, −12, −20, −40 dB labelled | Tick lines extend onto the bar so absolute level is readable at a glance. |
+| Numeric readout | Smoothed peak as a signed dB value | `-inf` or a signed value to one decimal place, e.g. `+0.0 dB` | Displays `-inf` when the signal is below approximately −59.5 dB. |
+
+### Level bar color meanings
+
+| Color | Approximate level | Meaning |
+|---|---|---|
+| Green | −60 dB to −12 dB | Plenty of headroom. |
+| Lime | −12 dB to −6 dB | Moderate level; normal operating range for most signals. |
+| Amber | −6 dB to −3 dB | Approaching clipping; consider reducing Drive or Output. |
+| Red | Above −3 dB | 3 dB or less from clipping. Reduce Drive or Output to bring the level down. |
+
+## Tips
+
+- The meter ballistics match those of the EQ Output Fader meter, so the visual feel is consistent if you use both applets side by side.
+- If the bar stays red during normal speech peaks, reduce the **Output** knob (range −24 dB to +12 dB, default 0.0 dB) or reduce the **Drive** knob (range 0 dB to 24 dB, default 0.0 dB) until amber or lower is typical for your signal peaks.
+- The slow-release ballistics (alpha = 0.08) mean the bar descends gradually after a peak, making it easier to catch transient overloads visually.
+
+## Related
+
+- [Output Level Meter overview](overview.md)

--- a/docs/features/client-tube/monitor-output-clipping-with-the-level-meter-in-the-editor.md
+++ b/docs/features/client-tube/monitor-output-clipping-with-the-level-meter-in-the-editor.md
@@ -1,0 +1,37 @@
+# Monitor output clipping with the level meter in the editor
+
+The floating Tube editor includes a live output level meter that shows the post-saturation peak level. Use it to confirm that Drive and Output settings are not clipping the processed signal before it leaves the tube stage.
+
+## Before you start
+
+- The Tube stage must be enabled on the side you want to monitor (TX or RX). See [Bypass the tube from either chain](bypass-the-tube-from-either-chain.md) if the stage is not yet active.
+- The floating editor must be open. The level meter is not visible in the docked applet tile.
+
+## Steps
+
+1. Double-click the TUBE stage in the CHAIN widget on the TX or RX side to open the floating editor. The TX editor is titled "Aetherial Tube — TX"; the RX editor is titled "Aetherial Tube — RX".
+2. Locate the "OUT" meter on the far right of the editor. It displays post-saturation peak level with fast-attack and slow-release ballistics.
+3. Pass audio through the stage — transmit or receive signal as appropriate — and observe the meter while adjusting Drive and Output.
+4. Keep the meter out of the red zone. The color bands indicate the following levels:
+
+   | Color | Range |
+   |-------|-------|
+   | Green | −60 to −12 dB |
+   | Lime  | −12 to −6 dB  |
+   | Amber | −6 to −3 dB   |
+   | Red   | Above −3 dB   |
+
+5. If the meter consistently reads red, reduce the Output knob (range −24.0 to 12.0 dB, default 0.00 dB, persisted as `ClientTubeTxOutputDb` or `ClientTubeRxOutputDb`) or reduce the Drive knob (range 0.0 to 24.0 dB, default 0.00 dB, persisted as `ClientTubeTxDriveDb` or `ClientTubeRxDriveDb`) until the meter stays in the amber or lower bands under typical signal conditions.
+
+## Tips
+
+- The meter reflects the signal after the tube stage. Reducing Drive affects harmonic character as well as level; reducing Output trims level only without changing the saturation curve.
+- The Dry/Wet knob (persisted as `ClientTubeTxDryWet` or `ClientTubeRxDryWet`) blends the dry signal back in. At values below 100 %, the meter will read lower because the unprocessed signal is mixed with the saturated output, which can mask how hard the tube itself is being driven.
+- Changes made in the floating editor are reflected on the docked applet tile knobs within approximately 33 ms via the sync timer, and vice versa.
+
+## Related
+
+- [Compensate level changes with Output](compensate-level-changes-with-output.md)
+- [Dial Drive until the curve starts to bend (TX warmth or RX tone shaping)](dial-drive-until-the-curve-starts-to-bend-tx-warmth-or-rx-tone-shaping.md)
+- [Parallel-blend saturation with Dry/Wet](parallel-blend-saturation-with-dry-wet.md)
+- [Bypass the tube from either chain](bypass-the-tube-from-either-chain.md)

--- a/docs/features/client-tube/parallel-blend-saturation-with-dry-wet.md
+++ b/docs/features/client-tube/parallel-blend-saturation-with-dry-wet.md
@@ -1,0 +1,41 @@
+# Parallel-blend saturation with Dry/Wet
+
+Use the Dry/Wet control to blend the saturated tube signal with the original unprocessed signal. Setting Dry/Wet below 100 % lets you dial in subtle harmonic color without fully replacing the clean signal.
+
+## Before you start
+
+- The Tube stage must be enabled for the side you want to adjust (TX or RX). See [Bypass the tube from either chain](bypass-the-tube-from-either-chain.md).
+- Open the floating editor for the relevant side: double-click the TUBE stage in the CHAIN widget to open "Aetherial Tube — TX" or "Aetherial Tube — RX".
+
+## Steps
+
+1. Open the floating editor by double-clicking the TUBE stage in the CHAIN widget on the TX or RX side.
+2. Locate the **Dry/Wet** knob in the left column of the editor (top knob in that column).
+3. Turn **Dry/Wet** toward 0 % to blend in more of the unprocessed signal, or toward 100 % for a fully saturated output.
+4. Watch the transfer curve and the **OUT** level meter on the right of the editor as you adjust. Reducing Dry/Wet lowers the contribution of the saturated signal; use **Output** to compensate if overall level changes.
+
+Alternatively, adjust **Mix** directly from the docked applet tile without opening the editor. The **Mix** knob on the tile is the same Dry/Wet control.
+
+## What each control does
+
+| Control | Default | Valid range | Persisted setting key |
+|---|---|---|---|
+| **Dry/Wet** (editor) / **Mix** (docked tile) | 100 % | 0 % to 100 % (stored as 0.0 to 1.0) | `ClientTubeTxDryWet` (TX), `ClientTubeRxDryWet` (RX) |
+
+## Tips
+
+- A Dry/Wet value between 20 % and 50 % is effective for adding warmth on SSB TX without audible distortion artifacts. The dry signal anchors the fundamental while the wet signal contributes harmonics.
+- Changes made in the floating editor and on the docked tile stay in sync. A 30 Hz polling timer keeps both views updated automatically.
+- If you raise **Drive** for more harmonic density, lowering **Dry/Wet** lets you recover a natural-sounding blend without reducing Drive itself.
+
+## Troubleshooting
+
+- **Adjusting Dry/Wet has no audible effect** — confirm the Tube stage is enabled. If the stage is bypassed in the CHAIN widget, the signal passes through unprocessed regardless of the Dry/Wet setting.
+- **Level changes when moving Dry/Wet** — this is expected. Use the **Output** knob (range −24.0 to 12.0 dB, default 0.00 dB) to trim the post-saturation level. See [Compensate level changes with Output](compensate-level-changes-with-output.md).
+
+## Related
+
+- [Bypass the tube from either chain](bypass-the-tube-from-either-chain.md)
+- [Compensate level changes with Output](compensate-level-changes-with-output.md)
+- [Dial Drive until the curve starts to bend (TX warmth or RX tone shaping)](dial-drive-until-the-curve-starts-to-bend-tx-warmth-or-rx-tone-shaping.md)
+- [Monitor output clipping with the level meter in the editor](monitor-output-clipping-with-the-level-meter-in-the-editor.md)

--- a/docs/features/client-tube/select-a-tube-character-model-a-b-or-c-to-change-harmonic-flavour.md
+++ b/docs/features/client-tube/select-a-tube-character-model-a-b-or-c-to-change-harmonic-flavour.md
@@ -1,0 +1,39 @@
+# Select a tube character (Model A, B, or C) to change harmonic flavour
+
+The tube character selector chooses which of three distinct saturation curves the tube stage uses, directly shaping the harmonic content added to your TX or RX audio. Switch models to compare flavours without changing any other parameter.
+
+## Before you start
+
+- The Tube stage must be enabled on the side you want to adjust (TX or RX). If the stage is bypassed, the model selection still persists but you will not hear a difference until you enable it.
+- Open the floating editor for the relevant side: double-click the TUBE stage in the CHAIN widget on the TX or RX side to open the "Aetherial Tube — TX" or "Aetherial Tube — RX" editor. The model selector is only available in the floating editor, not in the docked applet tile.
+
+## Steps
+
+1. Double-click the TUBE stage in the CHAIN widget on the TX or RX side. The frameless editor titled "Aetherial Tube — TX" or "Aetherial Tube — RX" opens.
+2. Locate the three toggle buttons labelled **A**, **B**, and **C** in the centre row of the editor, between the Tone knob and the Bias knob.
+3. Click **A**, **B**, or **C** to select a tube character. The selected button turns amber. Only one model can be active at a time.
+4. Watch the transfer curve: the curve shape updates immediately to reflect the selected character. The live input ball continues to ride the new curve.
+
+## What each control does
+
+| Control | Default | Valid values | Persisted setting |
+|---------|---------|--------------|-------------------|
+| **A** | Checked (active) | Selected / not selected | `ClientTubeTxModel` / `ClientTubeRxModel` (stored as integer: 0) |
+| **B** | Unchecked | Selected / not selected | `ClientTubeTxModel` / `ClientTubeRxModel` (stored as integer: 1) |
+| **C** | Unchecked | Selected / not selected | `ClientTubeTxModel` / `ClientTubeRxModel` (stored as integer: 2) |
+
+A, B, and C are mutually exclusive. Selecting one deselects the others. The same setting key (`ClientTubeTxModel` for TX, `ClientTubeRxModel` for RX) stores the choice for its respective side; TX and RX selections are fully independent.
+
+## Tips
+
+- The transfer curve display updates in real time when you switch models. Use this together with the live input ball to see how heavily your current Drive and Bias settings are bending the new curve before committing.
+- The TX and RX sides maintain independent model selections. Changing the model in "Aetherial Tube — TX" has no effect on "Aetherial Tube — RX" and vice versa.
+- After switching models, the harmonic mix may change noticeably at high Drive or Bias settings. If the level changes, adjust the Output knob to compensate.
+
+## Related
+
+- [Aetherial Mic-PreAmp (TX) / Aetherial Dynamic Tube (RX) overview](overview.md)
+- [Dial Drive until the curve starts to bend (TX warmth or RX tone shaping)](dial-drive-until-the-curve-starts-to-bend-tx-warmth-or-rx-tone-shaping.md)
+- [Shift Bias to tweak the harmonic balance](shift-bias-to-tweak-the-harmonic-balance.md)
+- [Compensate level changes with Output](compensate-level-changes-with-output.md)
+- [Bypass the tube from either chain](bypass-the-tube-from-either-chain.md)

--- a/docs/features/client-tube/shift-bias-to-tweak-the-harmonic-balance.md
+++ b/docs/features/client-tube/shift-bias-to-tweak-the-harmonic-balance.md
@@ -1,0 +1,46 @@
+# Shift Bias to tweak the harmonic balance
+
+The Bias knob moves the operating point on the tube transfer curve, changing the balance of even and odd harmonics the saturator produces. Use it to fine-tune the character of the saturation after you have set Drive.
+
+## Before you start
+
+- The Tube stage must be enabled on the side you want to adjust (TX or RX). See [Bypass the tube from either chain](bypass-the-tube-from-either-chain.md).
+- Drive should already be set high enough that the transfer curve is visibly bent. See [Dial Drive until the curve starts to bend (TX warmth or RX tone shaping)](dial-drive-until-the-curve-starts-to-bend-tx-warmth-or-rx-tone-shaping.md).
+- Open the floating editor by double-clicking the TUBE stage in the CHAIN widget on the TX or RX side. The editor is titled "Aetherial Tube — TX" or "Aetherial Tube — RX".
+
+## Steps
+
+1. Locate the Bias knob in the centre row of the editor, to the right of the A / B / C model selector.
+2. Turn Bias from its default of 0 % toward higher values (up to 100 %) to shift the operating point and increase asymmetric saturation.
+3. Watch the transfer curve: the curve shifts its bend point as you turn the knob. The live input ball tracks the new operating region in real time.
+4. Stop when the harmonic balance sounds correct for your use case.
+5. If the overall level changes noticeably, adjust the Output knob to compensate. See [Compensate level changes with Output](compensate-level-changes-with-output.md).
+
+## What each control does
+
+| Control | Default | Valid range | Persisted setting key |
+|---------|---------|-------------|-----------------------|
+| Bias (TX) | 0 % | 0 % to 100 % (internal 0.0 to 1.0) | `ClientTubeTxBias` |
+| Bias (RX) | 0 % | 0 % to 100 % (internal 0.0 to 1.0) | `ClientTubeRxBias` |
+
+The Bias knob uses a linear mapping. The displayed value is a percentage. Internally the setting is stored as a value from 0.0 to 1.0 in `ClientTubeTxBias` (TX side) or `ClientTubeRxBias` (RX side).
+
+## Tips
+
+- Bias interacts with the selected tube character. Try each of A, B, and C to hear how the same Bias value produces different harmonic results with different models.
+- The Bias knob is also present in the docked applet tile (the compact five-knob row beneath the transfer curve), so you can make quick adjustments without opening the full editor.
+- Changes made in the docked tile and the floating editor stay in sync; a 30 Hz timer keeps both views updated.
+
+## Troubleshooting
+
+- **Bias knob has no audible effect** — Drive may be at or near 0.00 dB. Bias only shifts the operating point meaningfully when the curve is already bent. Increase Drive first.
+- **Level changes when Bias is adjusted** — This is expected. The asymmetry introduced by Bias can raise or lower the apparent output. Trim the Output knob to compensate.
+
+## Related
+
+- [Dial Drive until the curve starts to bend (TX warmth or RX tone shaping)](dial-drive-until-the-curve-starts-to-bend-tx-warmth-or-rx-tone-shaping.md)
+- [Select a tube character (Model A, B, or C) to change harmonic flavour](select-a-tube-character-model-a-b-or-c-to-change-harmonic-flavour.md)
+- [Brighten or darken the saturated signal with Tone](brighten-or-darken-the-saturated-signal-with-tone.md)
+- [Compensate level changes with Output](compensate-level-changes-with-output.md)
+- [Monitor output clipping with the level meter in the editor](monitor-output-clipping-with-the-level-meter-in-the-editor.md)
+- [Bypass the tube from either chain](bypass-the-tube-from-either-chain.md)

--- a/docs/features/client-tube/tune-attack-and-release-for-natural-sounding-envelope-following.md
+++ b/docs/features/client-tube/tune-attack-and-release-for-natural-sounding-envelope-following.md
@@ -1,0 +1,49 @@
+# Tune Attack and Release for natural-sounding envelope following
+
+Attack and Release set how quickly the envelope follower tracks rising and falling signal levels. They only take effect when Envelope is set to a non-zero value. Dialing these two knobs prevents the tube character from snapping on and off unnaturally during speech or audio transients.
+
+## Before you start
+
+- The Tube stage must be enabled on the side you want to adjust (TX or RX). See [Bypass the tube from either chain](bypass-the-tube-from-either-chain.md).
+- Envelope must be set to a non-zero value. Attack and Release have no audible effect at 0 %. See [Use Envelope to add dynamic drive on transients](use-envelope-to-add-dynamic-drive-on-transients.md).
+- Open the floating editor for the side you want to adjust: double-click the TUBE stage in the CHAIN widget on the TX or RX side. The editor is titled "Aetherial Tube — TX" or "Aetherial Tube — RX".
+
+## Steps
+
+1. Open the floating editor by double-clicking the TUBE stage in the CHAIN widget on the TX or RX side.
+2. Locate the Attack knob in the right column of the editor.
+3. Adjust Attack to set how quickly the envelope follower responds when signal levels rise. Lower values make the follower react faster to transients; higher values smooth over short peaks.
+4. Locate the Release knob directly below Attack in the right column.
+5. Adjust Release to set how quickly the follower recovers after levels drop. Lower values return to the resting drive faster; higher values let the effect hang longer after a peak.
+6. Monitor the transfer curve and the live input ball while transmitting or receiving to confirm the drive modulation looks natural.
+
+## What each control does
+
+| Control | Default | Valid range | Persisted setting (TX / RX) |
+|---|---|---|---|
+| Attack | 5.00 ms | 0.1 to 30.0 ms | `ClientTubeTxAttackMs` / `ClientTubeRxAttackMs` |
+| Release | 35.00 ms | 10.0 to 500.0 ms | `ClientTubeTxReleaseMs` / `ClientTubeRxReleaseMs` |
+
+**Attack** — Uses exponential mapping across its range. Sets how quickly the envelope follower responds to rising signal levels when Envelope ≠ 0. The label displays as "X.XX ms" below 10 ms and "X.X ms" above 10 ms.
+
+**Release** — Uses exponential mapping across its range. Sets how quickly the envelope follower recovers after signal levels fall when Envelope ≠ 0. The label displays as "X.XX ms" below 100 ms and "X.X ms" above 100 ms.
+
+## Tips
+
+- Attack and Release are independent per side. Changes made in the TX editor do not affect the RX editor and vice versa.
+- For natural-sounding speech on TX, start with the defaults (Attack 5.00 ms, Release 35.00 ms) and lengthen Release first. Very short Release values can produce a pumping or chattering character.
+- For RX tone shaping, a longer Attack (10 ms or more) lets transient peaks pass through before the envelope follower engages, preserving initial consonants in received audio.
+- The live input ball on the transfer curve moves in real time. With Envelope set, you can see the operating point shifting as levels change, which helps confirm that Attack and Release feel right before going on air.
+
+## Troubleshooting
+
+- **Adjusting Attack or Release has no audible effect** — Envelope is likely set to 0 %. Set Envelope to a positive or negative value first; Attack and Release only apply when the envelope follower is active.
+- **The effect sounds too abrupt or chattery** — Release is set too low. Increase Release toward 100 ms or higher to smooth the recovery.
+- **Loud peaks cause the drive to snap on hard** — Attack is set too low. Increase Attack to 10–20 ms to slow the follower's response to transients.
+
+## Related
+
+- [Use Envelope to add dynamic drive on transients](use-envelope-to-add-dynamic-drive-on-transients.md)
+- [Dial Drive until the curve starts to bend (TX warmth or RX tone shaping)](dial-drive-until-the-curve-starts-to-bend-tx-warmth-or-rx-tone-shaping.md)
+- [Bypass the tube from either chain](bypass-the-tube-from-either-chain.md)
+- [Monitor output clipping with the level meter in the editor](monitor-output-clipping-with-the-level-meter-in-the-editor.md)

--- a/docs/features/client-tube/use-envelope-to-add-dynamic-drive-on-transients.md
+++ b/docs/features/client-tube/use-envelope-to-add-dynamic-drive-on-transients.md
@@ -1,0 +1,46 @@
+# Use Envelope to add dynamic drive on transients
+
+The Envelope knob connects an envelope follower to the tube drive, so the amount of saturation changes in real time with the input signal level. Use it on TX to add harmonic grit on mic transients, or on RX to make received audio feel more present on peaks.
+
+## Before you start
+
+- The Tube stage must be enabled for the side you want to adjust (TX or RX). If the applet is not visible, enable the stage via the CHAIN widget first.
+- Set Drive to a level where the transfer curve already shows some bend. Envelope modulates that drive; if Drive is at 0 dB the effect will be subtle.
+
+## Steps
+
+1. Double-click the TUBE stage in the CHAIN widget on the TX or RX side to open the floating editor titled "Aetherial Tube — TX" or "Aetherial Tube — RX".
+2. Locate the Envelope knob in the right column of the editor.
+3. Turn Envelope clockwise (positive) to increase drive on transients — the tube gets hotter as input levels rise. Turn it counter-clockwise (negative) to reduce drive on transients, compressing harmonics dynamically. Default is 0 %.
+4. Adjust Attack to set how quickly the envelope follower responds when levels rise. Lower values (toward 0.1 ms) react faster; higher values (toward 30.0 ms) smooth out short spikes.
+5. Adjust Release to set how quickly the follower recovers after levels drop. Lower values (toward 10.0 ms) recover faster; higher values (toward 500.0 ms) let the effect hang longer.
+6. Watch the live input ball on the transfer curve — with Envelope active, the ball will move further along the curve on peaks than on quiet passages, confirming the follower is working.
+
+## What each control does
+
+| Control | Default | Valid range | Persisted setting (TX / RX) | Behavior |
+|---|---|---|---|---|
+| Envelope | 0 % | −1.0 to +1.0 | `ClientTubeTxEnvelope` / `ClientTubeRxEnvelope` | Positive: boosts drive on loud peaks. Negative: reduces drive on loud peaks. Zero: no dynamic modulation. |
+| Attack | 5.00 ms | 0.1 to 30.0 ms | `ClientTubeTxAttackMs` / `ClientTubeRxAttackMs` | How quickly the follower responds to rising levels. Uses exponential scaling. Has no effect when Envelope is 0. |
+| Release | 35.00 ms | 10.0 to 500.0 ms | `ClientTubeTxReleaseMs` / `ClientTubeRxReleaseMs` | How quickly the follower recovers after levels fall. Uses exponential scaling. Has no effect when Envelope is 0. |
+
+## Tips
+
+- After setting a positive Envelope value, check the OUT meter in the editor. Peaks may be louder than the static Drive setting alone would produce; use the Output knob to compensate.
+- For natural-sounding TX mic grit, start with Envelope around +30 %, Attack at 5 ms, and Release at 50–80 ms, then adjust to taste.
+- Negative Envelope values behave like a dynamic saturation reducer — useful on RX to tame harsh peaks without removing tube character from quieter passages.
+- The Dry/Wet knob blends the fully processed signal (including envelope-modulated saturation) with the dry signal, so you can use high Envelope values without fully committing to the effect.
+
+## Troubleshooting
+
+- **Envelope knob has no audible effect** — Drive is likely at or near 0 dB. Set Drive to a value where the transfer curve visibly bends, then re-test Envelope.
+- **Effect sounds erratic or pumping** — Attack or Release values are too short for the program material. Increase Release toward 100 ms or more; increase Attack above 10 ms to ignore short transients.
+- **Output level spikes on transients** — Positive Envelope adds gain on peaks. Reduce Output to compensate, or reduce Envelope depth.
+
+## Related
+
+- [Dial Drive until the curve starts to bend (TX warmth or RX tone shaping)](dial-drive-until-the-curve-starts-to-bend-tx-warmth-or-rx-tone-shaping.md)
+- [Tune Attack and Release for natural-sounding envelope following](tune-attack-and-release-for-natural-sounding-envelope-following.md)
+- [Compensate level changes with Output](compensate-level-changes-with-output.md)
+- [Parallel-blend saturation with Dry/Wet](parallel-blend-saturation-with-dry-wet.md)
+- [Monitor output clipping with the level meter in the editor](monitor-output-clipping-with-the-level-meter-in-the-editor.md)

--- a/docs/features/panadapter/fix-a-static-stale-spectrum-in-a-popped-out-panadapter-on-macos.md
+++ b/docs/features/panadapter/fix-a-static-stale-spectrum-in-a-popped-out-panadapter-on-macos.md
@@ -1,0 +1,31 @@
+# Fix a static/stale spectrum in a popped-out panadapter on macOS
+
+On macOS, popping a panadapter out into a floating window can leave the spectrum frozen — the FFT and waterfall stop updating even though the radio is still connected. This is a known Metal/GPU surface issue that AetherSDR resolves automatically as of v0.9.5.1.
+
+## Before you start
+
+- AetherSDR v0.9.5.1 or later is installed. Earlier versions do not contain the fix.
+- You are running macOS with a FLEX-8600 connected.
+- You have more than one panadapter open (the ⬈ / ↩ pop-out button is hidden in single-pan mode).
+
+## Steps
+
+1. In the panadapter title bar, click ↩ to dock the floating panadapter back into the main window.
+2. Click ⬈ to pop it out again.
+
+AetherSDR resets the GPU resources and re-binds the Metal rendering surface to the new window during each float/dock cycle. After step 2 the spectrum should be live.
+
+## Tips
+
+- If the spectrum is still static after one dock/pop cycle, repeat the cycle once more. A stale WAN disconnect state can occasionally require a second reset.
+- Quitting and relaunching AetherSDR also clears the condition. The application releases GPU resources during shutdown specifically to prevent a Metal teardown crash in this scenario.
+
+## Troubleshooting
+
+- **The ⬈ pop-out button is not visible** — You are in single-pan mode. Add a second panadapter to enable multi-pan mode; the title bar buttons appear only when more than one panadapter is present.
+- **Spectrum is still frozen after dock/undock** — Confirm you are on v0.9.5.1 or later. Earlier builds do not call the GPU resource reset on float/dock cycles.
+
+## Related
+
+- [Pop a panadapter out into its own window](pop-a-panadapter-out-into-its-own-window.md)
+- [Panadapter overview](overview.md)

--- a/docs/features/phone-cw/enable-the-low-latency-cw-sidetone-sidetone-button-drives-both-radio-and-local-path.md
+++ b/docs/features/phone-cw/enable-the-low-latency-cw-sidetone-sidetone-button-drives-both-radio-and-local-path.md
@@ -1,0 +1,44 @@
+# Enable the low-latency CW sidetone (Sidetone button drives both radio and local path)
+
+Turning on the CW sidetone in AetherSDR enables two paths at once: the radio's DAX-fed monitor and a client-side tone generator with approximately 10 ms latency. A single button and a single volume slider control both in lockstep, so you hear a consistent tone regardless of network jitter.
+
+## Before you start
+
+- AetherSDR must be connected to the radio. The Phone/CW applet requires an active radio connection.
+- The active slice must be in a CW mode. The applet panel automatically switches from the Phone sub-panel to the CW sub-panel when CW mode is detected.
+
+## Steps
+
+1. If the Phone/CW applet is not visible, click the **P/CW** tray button on the right sidebar to open it.
+2. Confirm the CW sub-panel is displayed. If the Phone sub-panel is showing, switch the active slice to a CW mode on the radio; the panel switches automatically.
+3. Click **Sidetone** to enable the sidetone. The button lights up when active.
+4. Adjust the **Sidetone volume** slider to a comfortable level. The slider controls both the radio-side monitor volume and the client-side tone generator volume simultaneously.
+5. Optionally, adjust **Pitch < / >** to set the sidetone frequency. The pitch follows the radio's `cw_pitch` setting automatically, but you can step it in 10 Hz increments using the **<** and **>** controls.
+
+## What each control does
+
+| Control | Kind | Default | Valid range | Persisted key | Behavior |
+|---|---|---|---|---|---|
+| Sidetone | Toggle button | — | On / Off | — | Enables or disables the CW sidetone. Controls both the radio's DAX-fed monitor and the local low-latency tone generator in lockstep. |
+| Sidetone volume | Slider | — | 0–100 | — | Sets the volume for both the radio-side monitor (`mon_gain_cw`) and the client-side tone generator simultaneously. |
+| Pitch < / > | Spinbox | 600 Hz | 100–6000 Hz (step 10) | — | Steps the sidetone and decode pitch by 10 Hz. Automatically follows the radio's `cw_pitch` setting. |
+| L / R pan (CW) | Slider | 50 (centre) | 0–100 | — | Sets stereo pan for both the radio-side monitor and the local tone generator. Double-click recenters to 50. |
+
+## Tips
+
+- The client-side tone generator pitch and pan always follow the radio's `cw_pitch` and `mon_pan_cw` settings automatically. You do not need to configure them separately for the local path.
+- Double-clicking the **L / R pan (CW)** slider resets it to centre (50).
+
+## Troubleshooting
+
+- **No tone heard despite Sidetone being enabled** — Confirm the **Sidetone volume** slider is above 0. Also check that your system audio output device is correctly configured, as the client-side generator uses the local audio path.
+- **Sidetone button is not visible** — The CW sub-panel only appears when the active slice is in CW mode. Switch the active slice to CW on the radio; the applet panel switches automatically.
+- **Pitch does not match expectation** — Pitch follows the radio's `cw_pitch` setting. Adjust it using **Pitch < / >** in the applet, which updates the radio setting in 10 Hz steps.
+
+## Related
+
+- [Change CW pitch / sidetone frequency](change-cw-pitch-sidetone-frequency.md)
+- [Pan the CW sidetone left or right](pan-the-cw-sidetone-left-or-right.md)
+- [Listen to a TX sidetone monitor](listen-to-a-tx-sidetone-monitor.md)
+- [Set CW keying speed in WPM](set-cw-keying-speed-in-wpm.md)
+- [Set CW break-in delay](set-cw-break-in-delay.md)

--- a/docs/features/phone-cw/pan-the-cw-sidetone-left-or-right.md
+++ b/docs/features/phone-cw/pan-the-cw-sidetone-left-or-right.md
@@ -1,0 +1,34 @@
+# Pan the CW sidetone left or right
+
+Use the L / R pan control in the Phone/CW applet to shift the CW sidetone to the left or right stereo channel. The pan setting applies to both the radio's DAX-fed monitor and the client-side low-latency sidetone simultaneously.
+
+## Before you start
+
+- AetherSDR must be connected to the radio.
+- The active slice must be in a CW mode so the CW panel is visible in the Phone/CW applet.
+- Sidetone must be enabled. If it is not, click Sidetone in the Phone/CW applet to enable it.
+
+## Steps
+
+1. Click the **P/CW** tray button on the right sidebar to open the Phone/CW applet if it is not already visible.
+2. Confirm the applet shows the CW panel — the Sidetone, Delay, Speed, Breakin, Iambic, and Pitch controls must be visible. If the Phone panel is showing instead, switch the active slice to a CW mode.
+3. Locate the **L / R pan (CW)** slider.
+4. Drag the slider left to pan the sidetone toward the left channel, or right to pan toward the right channel.
+5. To return to centre, double-click the **L / R pan (CW)** slider.
+
+## What each control does
+
+| Control | Default | Valid range | Behavior |
+|---|---|---|---|
+| L / R pan (CW) | 50 (centre) | 0–100 | Sets the stereo pan position for the CW sidetone. Applies constant-power pan to both the radio-side monitor (`mon_pan_cw`) and the client-side sidetone generator in lockstep. Double-click recenters to 50. |
+
+## Tips
+
+- The pan position always follows the radio's `mon_pan_cw` setting. If another client or the radio itself changes `mon_pan_cw`, the slider will update automatically.
+- Double-clicking the slider is the fastest way to restore a centered sidetone without guessing the midpoint.
+
+## Related
+
+- [Enable the low-latency CW sidetone (Sidetone button drives both radio and local path)](enable-the-low-latency-cw-sidetone-sidetone-button-drives-both-radio-and-local-path.md)
+- [Change CW pitch / sidetone frequency](change-cw-pitch-sidetone-frequency.md)
+- [Listen to a TX sidetone monitor](listen-to-a-tx-sidetone-monitor.md)

--- a/docs/features/rx/fix-stale-slice-tabs-after-switching-to-a-radio-with-fewer-slices.md
+++ b/docs/features/rx/fix-stale-slice-tabs-after-switching-to-a-radio-with-fewer-slices.md
@@ -1,0 +1,39 @@
+# Fix stale slice tabs after switching to a radio with fewer slices
+
+When you disconnect from one radio and connect to another that has fewer slices, the RX applet's slice tab row (buttons A through H) may still show tabs from the previous session. This page explains how to clear those stale tabs and restore a clean state.
+
+## Before you start
+
+- You have already disconnected from the first radio and are connected to, or are about to connect to, a second radio with fewer available slices.
+- The RX applet is visible in the Applet Panel. If it is not, click the **RX** tray button on the right sidebar.
+
+## Steps
+
+1. Disconnect from the current radio if you have not already done so. Use `Settings > Connect to Radio...` to open the connection dialog, then close or cancel the existing connection.
+2. Observe the slice tab row at the top of the RX applet. If tabs (for example A, B, C, D) from the previous radio are still shown, they are stale.
+3. Connect to the new radio using `Settings > Connect to Radio...` and select the target radio.
+4. Once the new connection is established, AetherSDR calls `clearSliceButtons()` internally on disconnect, which tears down all generated slice tab buttons and restores the static slice badge. The slice tab row will then be repopulated to match the new radio's maximum slice count.
+5. Confirm that the slice tab row now shows only the correct number of tabs (capped at the new radio's hardware maximum). If the new radio supports only one slice, the tab row is hidden entirely and only the slice badge is shown.
+
+## What each control does
+
+| Control | Behavior | Default | Setting key |
+|---|---|---|---|
+| Slice tabs (A..H) | Selects which slice the RX applet is bound to. The row is hidden when the radio's maximum slice count is 1 or fewer. On disconnect, all generated tab buttons are removed and the static slice badge is restored. | — | — |
+| Slice badge | Displays the letter of the currently bound slice. Shown at all times; the only slice indicator visible when the tab row is hidden. | A | — |
+
+## Tips
+
+- Slice tab buttons are capped by the connected radio's hardware maximum. A radio that supports two slices will never show more than two tabs, regardless of what the previous radio had.
+- Duplicate signal handler connections are guarded across reconnects, so reconnecting to the same radio multiple times will not multiply the tab click responses.
+
+## Troubleshooting
+
+- **Stale tabs remain after reconnecting** — This can occur if the disconnect event did not fire cleanly. Disconnect again using `Settings > Connect to Radio...`, wait for the slice badge to reappear in place of the tabs, then reconnect.
+- **Tab row is missing entirely after connecting** — If the new radio reports a maximum slice count of 1 or fewer, the tab row is intentionally hidden. Only the slice badge is shown. This is expected behavior.
+
+## Related
+
+- [Switch between multiple slices using the A..H tab row](switch-between-multiple-slices-using-the-a-h-tab-row.md)
+- [RX Controls overview](overview.md)
+- [Understanding slices and VFOs](../../getting-started/concepts/understanding-slices.md)

--- a/docs/features/shack-switch/configure-a-dummy-load-antenna-to-protect-the-transmit-path.md
+++ b/docs/features/shack-switch/configure-a-dummy-load-antenna-to-protect-the-transmit-path.md
@@ -1,0 +1,40 @@
+# Configure a dummy load antenna to protect the transmit path
+
+Use the dummy load selector to designate one antenna port as a dummy load. When configured, Port B is automatically routed to that port to protect your antenna from unintended transmission.
+
+## Before you start
+
+- A ShackSwitch device must be discovered on the LAN or connected via the Peripherals tab in Radio Setup. The ShackSwitch applet appears automatically when a device is active.
+- The ShackSwitch applet must be visible. If it is not, click the SS tray button on the right sidebar.
+- At least one antenna must be present in the antenna list before a dummy load can be assigned.
+
+## Steps
+
+1. Open the ShackSwitch applet in the Applet Panel.
+2. Click the "Dummy Load: None" button near the bottom of the applet. A menu appears listing None and all available antenna names.
+3. Click the antenna name you want to designate as the dummy load. A checkmark appears next to the selected antenna and the button label updates to show the chosen antenna name.
+4. To remove the dummy load assignment, click the button again and select None.
+
+## What each control does
+
+| Control | Behavior | Default | Setting key |
+|---|---|---|---|
+| Dummy load selector button | Opens a menu to assign or clear the dummy load antenna. When an antenna is assigned, Port B is automatically routed to it. The button label reflects the current assignment. | None | `SS_DummyLoadAnt` |
+
+`SS_DummyLoadAnt` stores the integer antenna ID of the assigned dummy load. A value of `-1` means no dummy load is configured.
+
+## Tips
+
+- When a dummy load is configured and Port B is auto-routed to it, the [B] button on the intended antenna row blinks amber and the dummy load row's [B] button blinks orange. This gives you a visible indication that B has been parked on the dummy load rather than the antenna you selected.
+- The dummy load assignment persists across sessions via `SS_DummyLoadAnt`. You do not need to reconfigure it each time you connect.
+
+## Troubleshooting
+
+- **The antenna list in the menu is empty** — The ShackSwitch device has not yet reported any antenna ports. Confirm the device is connected and the status label shows a valid IP address and firmware version rather than a disconnected message.
+- **Port B is not routing to the dummy load** — Verify `SS_DummyLoadAnt` is set to a valid antenna ID (not `-1`) by checking that the dummy load selector button shows an antenna name rather than "Dummy Load: None".
+
+## Related
+
+- [ShackSwitch overview](overview.md)
+- [Select an antenna for ShackSwitch Input B](select-an-antenna-for-shackswitch-input-b.md)
+- [Resolve an Input A and Input B antenna conflict](resolve-an-input-a-and-input-b-antenna-conflict.md)

--- a/docs/features/shack-switch/open-the-shackswitch-web-configuration-interface.md
+++ b/docs/features/shack-switch/open-the-shackswitch-web-configuration-interface.md
@@ -1,0 +1,41 @@
+# Open the ShackSwitch web configuration interface
+
+The ShackSwitch device includes a built-in web interface for firmware-level configuration. This page explains how to open that interface from within AetherSDR using the "Settings ⚙" button in the ShackSwitch applet.
+
+## Before you start
+
+- The ShackSwitch applet must be visible in the Applet Panel. It appears automatically when a ShackSwitch device is discovered on the LAN, or after connecting via the Peripherals tab in Radio Setup.
+- If the device is not currently connected, AetherSDR falls back to the IP address stored in `SS_ManualIp`. Set that value before proceeding if you intend to open the web interface while disconnected.
+- Your system browser must be able to reach the ShackSwitch device on the network.
+
+## Steps
+
+1. Locate the ShackSwitch applet in the Applet Panel on the right side of the main window. If it is not visible, click the SS tray button on the right sidebar to show it.
+2. Click "Settings ⚙" at the bottom of the applet.
+3. AetherSDR constructs a URL from the device IP and web port, then opens it in your system browser.
+
+## What each control does
+
+| Control | Behavior | Persisted setting |
+|---|---|---|
+| "Settings ⚙" button | Opens the ShackSwitch device web configuration interface in the system browser. Uses the live peer address when connected; falls back to `SS_ManualIp` when disconnected. Port is taken from the device beacon's web port when that value is above 1024, otherwise from `SS_WebPort`, with a final fallback of 5000. | — |
+| `SS_ManualIp` | IP address used when no live device connection is present. | `SS_ManualIp` |
+| `SS_WebPort` | Web interface port used when the beacon does not advertise a valid port (above 1024). Default: `5000`. | `SS_WebPort` |
+
+## Tips
+
+- If the device is connected, AetherSDR uses the live peer address automatically. You do not need to set `SS_ManualIp` for normal connected operation.
+- The beacon web port is only trusted when it is above 1024. If the device firmware broadcasts port 80 as a placeholder, AetherSDR ignores it and uses `SS_WebPort` or the default of 5000 instead.
+- To open the web interface while the radio is offline, set `SS_ManualIp` to the device's static IP address in advance.
+
+## Troubleshooting
+
+- **Browser opens but the page does not load** — The device may be on a different subnet or behind a firewall. Confirm the IP shown in the ShackSwitch applet's status label is reachable from your machine. Check that the port (default `5000`) is not blocked.
+- **Nothing happens when clicking "Settings ⚙"** — AetherSDR will not open a URL if no IP address is available. Either connect to the device so the live address is used, or set `SS_ManualIp` to the device's IP address.
+- **Wrong port is used** — If the device serves its web interface on a non-default port and the beacon is not advertising it correctly, set `SS_WebPort` to the correct port number.
+
+## Related
+
+- [ShackSwitch overview](overview.md)
+- [Select an antenna for ShackSwitch Input A](select-an-antenna-for-shackswitch-input-a.md)
+- [Configure a dummy load antenna to protect the transmit path](configure-a-dummy-load-antenna-to-protect-the-transmit-path.md)

--- a/docs/features/shack-switch/overview.md
+++ b/docs/features/shack-switch/overview.md
@@ -1,0 +1,40 @@
+# ShackSwitch overview
+
+The ShackSwitch applet lets you control a ShackSwitch antenna switch directly from AetherSDR. Use it to assign antennas to one or two input ports, configure a dummy load for transmit protection, and open the device's web interface — all without leaving the application.
+
+## Before you start
+
+- A ShackSwitch device must be present on your LAN or added through the Peripherals tab in `Settings > Radio Setup...`. AetherSDR discovers ShackSwitch devices automatically via the AG UDP protocol.
+- The applet panel must be visible. If it is not, check `View > Applet Panel`.
+
+## How it works
+
+AetherSDR listens on the LAN for a device that identifies itself as a ShackSwitch. When one is found, the ShackSwitch applet appears automatically in the Applet Panel. Toggle its visibility using the ShackSwitch tray button on the right sidebar.
+
+The applet presents every antenna the device reports as a row in a list. Each row has an [A] button and, on dual-port devices, a [B] button. Clicking [A] or [B] routes that antenna to the corresponding input port. The INPUT A card (highlighted in cyan) and INPUT B card (highlighted in orange) always show the current band and antenna name for each port.
+
+If both ports are assigned to the same antenna, the affected [A] and [B] buttons blink amber to signal the conflict. When a dummy load is configured, Port B is automatically routed to the dummy load instead of the selected antenna while that condition applies; the intended row's [B] button blinks amber and the dummy load row's [B] button blinks orange to indicate the automatic rerouting.
+
+On single-port (R4) devices, the INPUT B card and the B column are hidden entirely.
+
+## What each control does
+
+| Control | Behavior | Persisted setting |
+|---|---|---|
+| Status label | Shows the connected device IP address and firmware version, or a disconnected message. | — |
+| INPUT A card | Displays the band and antenna name currently assigned to Port A. Highlighted in cyan. Shows — when no antenna is selected. | — |
+| INPUT B card | Displays the band and antenna name currently assigned to Port B. Highlighted in orange. Shows — when no antenna is selected. Hidden on single-port (R4) devices. | — |
+| [A] button (per antenna row) | Selects that antenna for Input A. Click again to deselect. Blinks amber when Port A and Port B are both assigned to the same antenna. | — |
+| [B] button (per antenna row) | Selects that antenna for Input B. Click again to deselect. Blinks amber on conflict. Blinks orange on the dummy load row when Port B is auto-routed there. | — |
+| Dummy load selector | Opens a menu to assign one antenna as the dummy load, or clear the assignment. When set, Port B is automatically routed to that antenna to protect the transmit path. Stored as an integer antenna ID; -1 means no dummy load is configured. | `SS_DummyLoadAnt` |
+| Settings ⚙ | Opens the ShackSwitch device web configuration interface in the system browser. Uses the live device IP when connected, falls back to `SS_ManualIp`. Port comes from the device beacon, `SS_WebPort`, or defaults to 5000. | `SS_ManualIp`, `SS_WebPort` |
+
+`SS_ControlPort` sets the UDP control port used to communicate with the device.
+
+## Related
+
+- [Select an antenna for ShackSwitch Input A](select-an-antenna-for-shackswitch-input-a.md)
+- [Select an antenna for ShackSwitch Input B](select-an-antenna-for-shackswitch-input-b.md)
+- [Configure a dummy load antenna to protect the transmit path](configure-a-dummy-load-antenna-to-protect-the-transmit-path.md)
+- [Resolve an Input A and Input B antenna conflict](resolve-an-input-a-and-input-b-antenna-conflict.md)
+- [Open the ShackSwitch web configuration interface](open-the-shackswitch-web-configuration-interface.md)

--- a/docs/features/shack-switch/resolve-an-input-a-and-input-b-antenna-conflict.md
+++ b/docs/features/shack-switch/resolve-an-input-a-and-input-b-antenna-conflict.md
@@ -1,0 +1,41 @@
+# Resolve an Input A and Input B antenna conflict
+
+A conflict occurs when both Input A and Input B are assigned to the same antenna. AetherSDR signals the conflict visually so you can reassign one input before transmitting.
+
+## Before you start
+
+- AetherSDR has discovered a ShackSwitch device and the ShackSwitch applet is visible in the Applet Panel.
+- The ShackSwitch device has at least two antenna ports available (the INPUT B card is not shown on single-port R4 devices, so a conflict is not possible on those).
+
+## Steps
+
+1. Look at the antenna rows in the ShackSwitch applet. When a conflict exists, the `[A]` button and the `[B]` button on the same antenna row both blink amber.
+2. Decide which input to move. Either click the `[A]` button on a different antenna row to reassign Input A, or click the `[B]` button on a different antenna row to reassign Input B.
+3. Confirm the blinking stops. The INPUT A card and INPUT B card should each show a different antenna name, and neither button blinks.
+
+## What each control does
+
+| Control | Behavior | Setting key |
+|---|---|---|
+| `[A]` button (per antenna row) | Selects that antenna for Input A. Clicking an already-selected antenna deselects it. Blinks amber when Input A and Input B are both assigned to the same antenna. | — |
+| `[B]` button (per antenna row) | Selects that antenna for Input B. Clicking an already-selected antenna deselects it. Blinks amber when conflicting. When a dummy load is configured and Input B is auto-routed there, the intended row `[B]` button blinks amber and the dummy load row `[B]` button blinks orange. | — |
+| INPUT A card | Shows the current band and antenna name assigned to Port A. Displays — when no antenna is selected. | — |
+| INPUT B card | Shows the current band and antenna name assigned to Port B. Displays — when no antenna is selected. Hidden on single-port R4 devices. | — |
+| Dummy load selector | Assigns an antenna as the dummy load. When configured, Port B is automatically routed to the dummy load, which can cause the amber blink on the intended antenna row. | `SS_DummyLoadAnt` |
+
+## Tips
+
+- If the conflict reappears immediately after you reassign an input, check whether a dummy load is configured. When `SS_DummyLoadAnt` is set, Port B is automatically routed to the dummy load antenna. If that antenna is the same one assigned to Input A, the conflict will persist until you either change the Input A selection or reconfigure the dummy load.
+- Clicking an already-active `[A]` or `[B]` button deselects that input entirely, leaving the corresponding card showing —. This is a valid way to clear one side of the conflict if you intend to leave that input unassigned.
+
+## Troubleshooting
+
+- **Buttons keep blinking after reassignment** — A dummy load may be auto-routing Input B back to the conflicting antenna. Open the Dummy load selector and check which antenna is set. Select a different antenna or choose None to clear it.
+- **INPUT B card is not visible** — The connected device is a single-port R4 ShackSwitch. Input B is not available on this device; a two-input conflict cannot occur.
+
+## Related
+
+- [Configure a dummy load antenna to protect the transmit path](configure-a-dummy-load-antenna-to-protect-the-transmit-path.md)
+- [Select an antenna for ShackSwitch Input A](select-an-antenna-for-shackswitch-input-a.md)
+- [Select an antenna for ShackSwitch Input B](select-an-antenna-for-shackswitch-input-b.md)
+- [ShackSwitch overview](overview.md)

--- a/docs/features/shack-switch/select-an-antenna-for-shackswitch-input-a.md
+++ b/docs/features/shack-switch/select-an-antenna-for-shackswitch-input-a.md
@@ -1,0 +1,47 @@
+# Select an antenna for ShackSwitch Input A
+
+Use the ShackSwitch applet to route a specific antenna to Input A on your ShackSwitch device. This controls which antenna your radio's Port A uses for receive and transmit.
+
+## Before you start
+
+- A ShackSwitch device must be discovered on the LAN or connected via the Peripherals tab in Radio Setup. The applet appears automatically when a device is found.
+- The ShackSwitch applet must be visible in the Applet Panel. If it is not visible, click the SS tray button on the right sidebar to show it.
+
+## Steps
+
+1. Open the Applet Panel. If the ShackSwitch applet is not visible, click the SS tray button on the right sidebar.
+2. Locate the antenna list in the applet. Each antenna appears as a row with an antenna name and one or two buttons labeled `[A]` and `[B]`.
+3. Find the row for the antenna you want to assign to Input A.
+4. Click the `[A]` button in that row.
+5. Confirm the selection: the INPUT A card at the top of the applet updates to show the antenna name you selected.
+
+To deselect the current Input A antenna without choosing another, click the active `[A]` button again. The INPUT A card will return to showing —.
+
+## What each control does
+
+| Control | Behavior | Setting key |
+|---|---|---|
+| INPUT A card | Displays the band and antenna name currently assigned to Port A. Shows — when no antenna is selected. | — |
+| `[A]` button (per antenna row) | Selects that antenna for Input A. Click again to deselect. Blinks amber when Port A and Port B are both assigned to the same antenna. | — |
+| Status label | Shows the connected device IP address and firmware version, or a disconnected message. | — |
+| Dummy load selector | Designates one antenna as a dummy load. When set, Port B is automatically routed to the dummy load to protect the antenna during transmit. | `SS_DummyLoadAnt` |
+| Settings ⚙ | Opens the ShackSwitch device web configuration interface in the system browser. Falls back to `SS_ManualIp` if no live connection is available. Port is taken from `SS_WebPort` or defaults to 5000. | `SS_ManualIp`, `SS_WebPort` |
+
+## Tips
+
+- The `[A]` button highlights in cyan when active, matching the cyan color of the INPUT A card. An unselected `[A]` button is shown in a muted style.
+- On single-port (R4) devices, the INPUT B card and `[B]` buttons are hidden. Only Input A selection is available.
+
+## Troubleshooting
+
+- **The `[A]` button blinks amber after selection** — Both Input A and Input B are now assigned to the same antenna. This is a conflict. See [Resolve an Input A and Input B antenna conflict](resolve-an-input-a-and-input-b-antenna-conflict.md) to resolve it.
+- **The antenna list is empty** — The applet has not yet received antenna data from the device. Check that the ShackSwitch is reachable on the LAN and that the status label shows a connected IP address rather than a disconnected message.
+- **The INPUT A card still shows — after clicking `[A]`** — The device may not have confirmed the selection yet. Verify the status label shows a connected device. If the device is disconnected, the command cannot be sent.
+
+## Related
+
+- [ShackSwitch overview](overview.md)
+- [Select an antenna for ShackSwitch Input B](select-an-antenna-for-shackswitch-input-b.md)
+- [Resolve an Input A and Input B antenna conflict](resolve-an-input-a-and-input-b-antenna-conflict.md)
+- [Configure a dummy load antenna to protect the transmit path](configure-a-dummy-load-antenna-to-protect-the-transmit-path.md)
+- [Open the ShackSwitch web configuration interface](open-the-shackswitch-web-configuration-interface.md)

--- a/docs/features/shack-switch/select-an-antenna-for-shackswitch-input-b.md
+++ b/docs/features/shack-switch/select-an-antenna-for-shackswitch-input-b.md
@@ -1,0 +1,43 @@
+# Select an antenna for ShackSwitch Input B
+
+Use the ShackSwitch applet to assign an antenna to Input B. Input B is the second port on multi-port ShackSwitch devices and is not available on single-port (R4) models.
+
+## Before you start
+
+- A ShackSwitch device must be discovered on the LAN or connected via the Peripherals tab in Radio Setup. The applet appears automatically when a device is active.
+- The ShackSwitch applet must be visible in the Applet Panel. If it is not visible, click the SS tray button on the right sidebar.
+- Confirm the INPUT B card is shown in the applet. If it is hidden, your device is a single-port (R4) model and Input B is not available.
+
+## Steps
+
+1. Open the Applet Panel and locate the ShackSwitch applet.
+2. Find the antenna row you want to assign to Input B. Antenna names are listed under the ANTENNA column.
+3. Click the **[B]** button on that antenna row. The button highlights in orange to confirm the selection.
+4. Confirm the INPUT B card at the top of the applet updates to show the selected antenna name.
+
+To deselect the current Input B antenna, click its active **[B]** button again.
+
+## What each control does
+
+| Control | Behavior | Setting key |
+|---|---|---|
+| INPUT B card | Displays the current band and antenna name assigned to Port B. Hidden on single-port (R4) devices. | — |
+| **[B]** button (per antenna row) | Selects this antenna for Input B. Click again to deselect. Blinks amber when Port A and Port B are both assigned to the same antenna. | — |
+| Dummy load selector | Opens a menu to designate one antenna as a dummy load. When configured, Port B is automatically routed to the dummy load to protect the antenna during transmit. | `SS_DummyLoadAnt` |
+
+## Tips
+
+- If the **[B]** button blinks amber after you select an antenna, both inputs are now assigned to the same antenna. See [Resolve an Input A and Input B antenna conflict](resolve-an-input-a-and-input-b-antenna-conflict.md).
+- If a dummy load is configured and Port B is auto-routed there, the **[B]** button on your intended antenna row blinks amber and the dummy load row's **[B]** button blinks orange. To override this behavior, remove the dummy load assignment using the Dummy load selector.
+
+## Troubleshooting
+
+- **The INPUT B card and [B] buttons are not visible** — Your ShackSwitch device is a single-port (R4) model. Input B is not available on that hardware.
+- **Clicking [B] has no effect** — The applet status label shows "Not connected". The ShackSwitch device is not reachable. Verify the device is powered and on the same network segment. Check `SS_ManualIp` and `SS_ControlPort` in Radio Setup if auto-discovery is not working.
+
+## Related
+
+- [Select an antenna for ShackSwitch Input A](select-an-antenna-for-shackswitch-input-a.md)
+- [Resolve an Input A and Input B antenna conflict](resolve-an-input-a-and-input-b-antenna-conflict.md)
+- [Configure a dummy load antenna to protect the transmit path](configure-a-dummy-load-antenna-to-protect-the-transmit-path.md)
+- [Open the ShackSwitch web configuration interface](open-the-shackswitch-web-configuration-interface.md)

--- a/docs/features/tci/fix-tci-tx-silent-on-windows-or-linux-without-pipewire.md
+++ b/docs/features/tci/fix-tci-tx-silent-on-windows-or-linux-without-pipewire.md
@@ -1,0 +1,54 @@
+# Fix TCI TX Silent on Windows or Linux without PipeWire
+
+TCI TX audio is routed through a dedicated `dax_tx` stream slot inside AetherSDR's TCI server, independent of the Windows SmartSDR DAX2 audio device path and independent of PipeWire. This means TCI TX should work on all platforms without any special configuration. This page helps you confirm the TCI server is set up correctly and the TX gain is not the cause of silence.
+
+## Before you start
+
+- AetherSDR must be connected to the radio. The TCI applet requires an active radio connection.
+- The third-party application sending TCI TX audio (for example, a digital-mode program) must be configured to connect to AetherSDR's TCI server, not to SmartSDR DAX2 or any other audio device.
+- Make sure you are running AetherSDR v0.9.5.1 or later. Earlier versions had a platform-dependent TX audio policy that could block TX audio on Windows and Linux without PipeWire.
+
+## Steps
+
+1. Click the **TCI** tray button on the right sidebar to open the TCI Server applet.
+2. Check the server status label next to the Port field.
+   - If it reads `(stopped)`, click **Enable** to start the server.
+   - If it reads `(port in use)`, the chosen port is already bound by another process. Change the value in the **Port** field to a free port (valid range: 1024–65535; default: `50001`), then press Enter and click **Enable**.
+3. Confirm the status label shows `:<port> (N clients)` with at least one client connected. If your TX application is not shown as a connected client, check its TCI host and port settings and ensure they match the **Port** field value.
+4. Look at the **TX** row in the applet. Check the slice-assignment label next to the TX meter.
+   - If it shows `—`, no slice is currently designated as the TX slice. Use the radio's slice controls to assign a TX slice.
+   - If it shows `Slice <letter>`, the TX path is active.
+5. Drag the **TX gain+meter** slider to confirm it is not set to `0.0`. The default is `0.5` (valid range: 0.0–1.0, persisted as `TciTxGain`). A value of `0.0` produces silence regardless of platform.
+6. Key the transmitter from your third-party application and watch the **TX gain+meter** for level movement. If the meter shows activity, audio is reaching the server and the radio should be transmitting.
+
+## What each control does
+
+| Control | Default | Valid range | Persisted key |
+|---|---|---|---|
+| **Port** | `50001` | 1024–65535 | `TciPort` |
+| **Enable** | Off | On / Off | — |
+| **TX gain+meter** | `0.5` | 0.0–1.0 | `TciTxGain` |
+| **RX1 gain+meter** | `0.5` | 0.0–1.0 | `TciRxGain1` |
+| **RX2 gain+meter** | `0.5` | 0.0–1.0 | `TciRxGain2` |
+| **RX3 gain+meter** | `0.5` | 0.0–1.0 | `TciRxGain3` |
+| **RX4 gain+meter** | `0.5` | 0.0–1.0 | `TciRxGain4` |
+
+## Tips
+
+- Out-of-range port values snap back to `50001` automatically.
+- If you want the TCI server to start every time AetherSDR launches, enable `Settings > Autostart TCI with AetherSDR`. This sets the `AutoStartTCI` flag and also checks **Enable** on startup.
+- The TX meter uses fast attack and slow decay smoothing, so a brief transmission will keep the meter visibly elevated for a moment after audio stops. No movement at all during a keyed transmission confirms audio is not arriving from the client.
+
+## Troubleshooting
+
+- **Status shows `(port in use)` and Enable snaps back to off** — Another application is bound to that port. Enter a different port number in the **Port** field, press Enter, and click **Enable** again.
+- **Status shows the correct port and client count, but the radio is not transmitting audio** — Confirm the TX slice label in the **TX** row shows `Slice <letter>` and not `—`. If it shows `—`, designate a TX slice from the main UI. Also confirm the **TX gain+meter** is above `0.0`.
+- **Third-party application cannot connect** — Verify the application is pointed at `localhost` (or AetherSDR's host IP) and the port number matches the **Port** field. Confirm no firewall rule is blocking the port.
+- **TX meter shows no movement despite the client being connected and keyed** — The client application may be sending audio to a system audio device rather than over the TCI WebSocket. Check the client's audio output or TCI audio routing settings. AetherSDR does not use the Windows DAX2 audio device for TCI TX; audio must arrive over the WebSocket connection.
+
+## Related
+
+- [Enable the TCI server for Log4OM / SunSDR clients](enable-the-tci-server-for-log4om-sunsdr-clients.md)
+- [Adjust TCI TX gain](adjust-tci-tx-gain.md)
+- [Change the TCI port](change-the-tci-port.md)
+- [Autostart TCI on launch](autostart-tci-on-launch.md)

--- a/docs/features/vfo-widget/adjust-af-gain-and-pan-from-the-vfo-panel.md
+++ b/docs/features/vfo-widget/adjust-af-gain-and-pan-from-the-vfo-panel.md
@@ -1,0 +1,35 @@
+# Adjust AF gain and pan from the VFO panel
+
+Use the Audio tab in the VFO panel to set the audio output level and stereo pan position for any receive slice independently of other slices.
+
+## Before you start
+
+- AetherSDR must be connected to the radio. The VFO panel requires an active radio connection.
+- The VFO panel for the target slice must be open. If it is collapsed to a frequency-only strip, click anywhere on the collapsed strip to expand it.
+
+## Steps
+
+1. Click the VFO marker flag on the spectrum display for the slice you want to adjust. The VFO panel opens anchored to the marker.
+2. Click the **Audio** tab inside the VFO panel.
+3. To set the audio output level, drag the **AF Gain slider** left or right. The default is 100; the valid range is 0–100.
+4. To set the stereo position, drag the **Pan slider** left or right. The default is 50 (centre); the valid range is 0–100. A value below 50 moves audio toward the left channel; above 50 toward the right.
+
+## What each control does
+
+| Control | Default | Range | Behavior |
+|---|---|---|---|
+| AF Gain slider (Audio tab) | 100 | 0–100 | Sets the audio output level for this slice. Not persisted — reflects live radio state. |
+| Pan slider (Audio tab) | 50 | 0–100 | Sets left/right stereo pan for this slice. 50 = centre. |
+
+## Tips
+
+- Double-clicking either slider resets it to its default value: 100 for AF Gain, 50 for Pan.
+- AF gain is per-slice. Adjusting one slice does not affect any other slice.
+- To silence a slice without moving the AF Gain slider, use the **Mute button** on the Audio tab instead. Muting does not change the stored gain value.
+
+## Related
+
+- [Mute audio for a slice from the VFO panel](mute-audio-for-a-slice-from-the-vfo-panel.md)
+- [Enable squelch from the VFO panel](enable-squelch-from-the-vfo-panel.md)
+- [Collapse the VFO panel to frequency-only view](collapse-the-vfo-panel-to-frequency-only-view.md)
+- [VFO Panel overview](overview.md)

--- a/docs/features/vfo-widget/apply-a-filter-width-preset-from-the-vfo-panel.md
+++ b/docs/features/vfo-widget/apply-a-filter-width-preset-from-the-vfo-panel.md
@@ -1,0 +1,40 @@
+# Apply a filter width preset from the VFO panel
+
+Filter preset buttons let you switch the receive filter width for a slice with a single click. Use them to move quickly between common bandwidths — for example, between a wide 3 kHz SSB filter and a narrow 500 Hz CW filter — without leaving the spectrum view.
+
+## Before you start
+
+- AetherSDR must be connected to the radio. The VFO panel requires an active radio connection.
+- The VFO panel for the target slice must be open and expanded. If it is collapsed to a frequency-only strip, click anywhere on it to expand it first.
+
+## Steps
+
+1. Click the VFO marker flag on the spectrum display for the slice you want to adjust. The VFO panel opens, anchored to the left of the marker.
+2. Click the **Mode** tab inside the VFO panel.
+3. Click the filter preset button that corresponds to the bandwidth you want. The radio immediately applies that filter width to the slice.
+
+To save the current filter width into a preset slot:
+
+1. Set the filter to the bandwidth you want to save (see [Set a custom filter edge from the VFO panel](set-a-custom-filter-edge-from-the-vfo-panel.md)).
+2. Right-click the preset button slot you want to overwrite.
+3. The current filter width is saved into that slot.
+
+## What each control does
+
+| Control | Behavior | Default | Setting key |
+|---|---|---|---|
+| Filter preset buttons (Mode tab) | Each button applies a saved filter width preset to the slice. Left-click to apply; right-click to save the current filter width into that slot. Custom low and high filter edges can be stored per slot via right-click. | — | `FilterPresets` |
+| Filter width label | Displays the current filter bandwidth. Click to cycle through the filter preset buttons in the Mode tab. | — | — |
+
+## Tips
+
+- The filter width label in the VFO panel header shows the active bandwidth at all times. Click it directly to cycle through the preset buttons without switching to the Mode tab first.
+- Preset slots are shared across all slices and modes. Overwriting a slot affects every slice that uses it.
+- Filter edge lines on the spectrum panadapter reflect the active filter width. If the lines are hidden, enable them with the Filter edges button in the VFO panel. See [Hide or show filter edge lines on the spectrum](hide-or-show-filter-edge-lines-on-the-spectrum.md).
+
+## Related
+
+- [Set a custom filter edge from the VFO panel](set-a-custom-filter-edge-from-the-vfo-panel.md)
+- [Change mode from the VFO panel](change-mode-from-the-vfo-panel.md)
+- [Hide or show filter edge lines on the spectrum](hide-or-show-filter-edge-lines-on-the-spectrum.md)
+- [VFO Panel overview](overview.md)

--- a/docs/features/vfo-widget/assign-a-dax-channel-from-the-vfo-panel.md
+++ b/docs/features/vfo-widget/assign-a-dax-channel-from-the-vfo-panel.md
@@ -1,0 +1,41 @@
+# Assign a DAX channel from the VFO panel
+
+DAX (Digital Audio Exchange) routes a slice's received audio to a named audio channel on your computer. Use this procedure to assign or change the DAX channel for any slice directly from its VFO panel.
+
+## Before you start
+
+- AetherSDR must be connected to the radio. The VFO panel requires an active radio connection.
+- The DAX audio bridge must be running. If it is not, enable it via `Settings > Autostart DAX with AetherSDR` and restart AetherSDR, or start it manually.
+- The VFO panel for the target slice must be open and expanded. If it is collapsed to the frequency-only strip, click anywhere on it to expand it.
+
+## Steps
+
+1. Click the VFO marker flag on the spectrum display for the slice you want to configure. The VFO panel opens, anchored to the left of the marker.
+2. Click the **DAX** tab inside the VFO panel.
+3. Click the **DAX channel combo** and select a channel from the drop-down list.
+4. To disable DAX routing for this slice, select **Off**.
+
+## What each control does
+
+| Control | Default | Valid values | Persisted setting key |
+|---|---|---|---|
+| DAX channel combo | Off | Off, 1–8 | — |
+
+The DAX channel combo assigns a DAX audio channel to the current slice. Selecting a numbered channel routes the slice's received audio to that DAX channel. Selecting **Off** removes the assignment. This setting reflects live radio state and is not persisted locally by AetherSDR.
+
+## Tips
+
+- Each DAX channel can be assigned to only one slice at a time. If you assign a channel that is already in use by another slice, the radio will move the assignment.
+- If the VFO panel would be clipped by the window edge, it flips to the right side of the marker automatically.
+
+## Troubleshooting
+
+- **DAX channel combo has no effect / audio does not appear on the host** — Confirm the DAX audio bridge is running. Check `Settings > Autostart DAX with AetherSDR`. On macOS and PipeWire systems, the bridge must be active for DAX channels to appear as audio devices.
+- **DAX tab is not visible** — The VFO panel may be collapsed. Click the collapsed strip to expand it, then select the DAX tab.
+
+## Related
+
+- [VFO Panel overview](overview.md)
+- [Adjust AF gain and pan from the VFO panel](adjust-af-gain-and-pan-from-the-vfo-panel.md)
+- [Mute audio for a slice from the VFO panel](mute-audio-for-a-slice-from-the-vfo-panel.md)
+- [Collapse the VFO panel to frequency-only view](collapse-the-vfo-panel-to-frequency-only-view.md)

--- a/docs/features/vfo-widget/change-mode-from-the-vfo-panel.md
+++ b/docs/features/vfo-widget/change-mode-from-the-vfo-panel.md
@@ -1,0 +1,36 @@
+# Change mode from the VFO panel
+
+Use the VFO panel's Mode tab to switch the demodulation mode for any slice — for example, from USB to CW or FM — without leaving the spectrum view.
+
+## Before you start
+
+- AetherSDR must be connected to the radio. The VFO panel requires an active radio connection.
+- The VFO panel must be open. If it is not visible, click the VFO marker flag on the spectrum display for the slice you want to change.
+
+## Steps
+
+1. Click the VFO marker flag on the spectrum display for the target slice. The VFO panel opens, anchored to the left of the marker.
+2. Click the **Mode** tab inside the VFO panel.
+3. Click the **Mode combo** and select the desired mode from the list.
+
+## What each control does
+
+| Control | Default | Valid values | Persisted setting |
+|---|---|---|---|
+| Mode combo | USB | USB, LSB, CW, CWL, AM, SAM, DIGU, DIGL, FM, NFM, DFM, RTTY | — |
+| Filter preset buttons | — | Saved filter width presets | `FilterPresets` |
+
+**Mode combo** — sets the demodulation mode for the slice. Selecting a new mode takes effect immediately on the radio.
+
+**Filter preset buttons** — appear on the same Mode tab. Each button applies a saved filter width. Right-click a button to save the current filter width into that slot. Presets are persisted in `FilterPresets`.
+
+## Tips
+
+- Changing mode may alter the active filter passband. Check the filter width label in the header row after switching modes, and apply a filter preset if needed.
+- The filter width label in the VFO panel header shows the current bandwidth. Click it to cycle through the filter preset buttons on the Mode tab.
+
+## Related
+
+- [Apply a filter width preset from the VFO panel](apply-a-filter-width-preset-from-the-vfo-panel.md)
+- [Set a custom filter edge from the VFO panel](set-a-custom-filter-edge-from-the-vfo-panel.md)
+- [VFO Panel overview](overview.md)

--- a/docs/features/vfo-widget/change-the-vfo-marker-line-thickness.md
+++ b/docs/features/vfo-widget/change-the-vfo-marker-line-thickness.md
@@ -1,0 +1,34 @@
+# Change the VFO Marker Line Thickness
+
+Use the marker thickness button to control how prominent the VFO marker line appears on the spectrum display, or to hide it entirely. The setting is saved per slice.
+
+## Before you start
+
+- AetherSDR must be connected to a FLEX-8600 radio.
+- The VFO panel must be open for the slice you want to adjust. If it is not visible, click the VFO marker flag for that slice on the spectrum display.
+
+## Steps
+
+1. Open the VFO panel for the target slice by clicking its VFO marker flag on the spectrum display.
+2. Locate the **Marker thickness button** in the VFO panel.
+3. Click the button to cycle through the available values: **Off**, **1 px**, and **3 px**.
+4. Stop clicking when the desired thickness is shown. The marker on the spectrum display updates immediately.
+
+## What each control does
+
+| Control | Default | Valid values | Persisted setting |
+|---|---|---|---|
+| Marker thickness button | 1 px | Off, 1 px, 3 px | `Slice{N}_MarkerWidth` |
+
+Each click advances to the next value in the cycle: **Off** → **1 px** → **3 px** → **Off**. The setting is persisted per slice, so slice 1 and slice 2 can have different thicknesses.
+
+## Tips
+
+- Setting the marker to **Off** hides the vertical line entirely. The VFO panel and flag remain visible and functional.
+- If you run multiple slices on the same panadapter, increasing one marker to **3 px** can help distinguish it from adjacent slices.
+
+## Related
+
+- [Hide or show filter edge lines on the spectrum](hide-or-show-filter-edge-lines-on-the-spectrum.md)
+- [Collapse the VFO panel to frequency-only view](collapse-the-vfo-panel-to-frequency-only-view.md)
+- [VFO Panel overview](overview.md)

--- a/docs/features/vfo-widget/collapse-the-vfo-panel-to-frequency-only-view.md
+++ b/docs/features/vfo-widget/collapse-the-vfo-panel-to-frequency-only-view.md
@@ -1,0 +1,35 @@
+# Collapse the VFO panel to frequency-only view
+
+When screen space is limited, you can collapse the VFO panel to a compact strip that shows only the slice frequency. The collapsed state is saved per slice so it persists across sessions.
+
+## Before you start
+
+- AetherSDR must be connected to the radio. The VFO panel requires a live radio connection.
+- The VFO panel for the slice must be open. If it is not visible, click the VFO marker flag on the spectrum display for that slice.
+
+## Steps
+
+1. Locate the slice badge in the header area of the VFO panel. The badge shows the slice identifier (for example, **A** or **B**).
+2. Click the slice badge. The panel collapses to a compact frequency-only strip.
+3. To restore the full panel, click anywhere on the collapsed strip.
+
+## What each control does
+
+| Control | Default | Persisted setting |
+|---|---|---|
+| Collapse toggle | Expanded | `SliceFlagCollapsed_{N}` |
+
+The `SliceFlagCollapsed_{N}` setting is stored per slice, where `{N}` is the slice number. Collapsing one slice does not affect other slices.
+
+## Tips
+
+- In collapsed view, scrolling the mouse wheel over the strip tunes the slice frequency by the current step size — the same as scrolling over the frequency display in the full panel.
+- In collapsed view, clicking the TX badge painted on the strip toggles the TX assignment for that slice. Clicking anywhere else on the strip expands the panel.
+- The panel flips to the right side of the VFO marker automatically if expanding it would be clipped by the window edge. This behavior applies in both expanded and collapsed states.
+
+## Related
+
+- [VFO Panel overview](overview.md)
+- [Tune the radio by typing a frequency into the VFO panel](tune-the-radio-by-typing-a-frequency-into-the-vfo-panel.md)
+- [Change the VFO marker line thickness](change-the-vfo-marker-line-thickness.md)
+- [Hide or show filter edge lines on the spectrum](hide-or-show-filter-edge-lines-on-the-spectrum.md)

--- a/docs/features/vfo-widget/enable-noise-reduction-from-the-vfo-panel.md
+++ b/docs/features/vfo-widget/enable-noise-reduction-from-the-vfo-panel.md
@@ -1,0 +1,43 @@
+# Enable noise reduction from the VFO panel
+
+Use the DSP tab in the VFO panel to switch on one or more noise reduction algorithms for a slice. Each algorithm targets a different noise type; you can enable them independently.
+
+## Before you start
+
+- AetherSDR must be connected to the radio. The VFO panel requires an active radio connection.
+- The VFO panel for the slice must be open and expanded. If it is collapsed to a frequency-only strip, click anywhere on it to expand it.
+
+## Steps
+
+1. Click the VFO marker flag on the spectrum display for the slice you want to adjust. The VFO panel opens anchored to the marker.
+2. Click the **DSP** tab inside the VFO panel.
+3. Click the button for the noise reduction algorithm you want to enable: **NR**, **NR2**, **RN2**, **NR4**, **MNR**, **DFNR**, **BNR**, **NRL**, **NRS**, **RNN**, or **NRF**. The button highlights when active.
+4. To disable noise reduction, click the same button again. The highlight clears.
+
+## What each control does
+
+| Control | Default | Behavior |
+|---|---|---|
+| **NR** | off | Enables the standard noise reduction algorithm for this slice. |
+| **NR2** | off | Enables the NR2 noise reduction algorithm. Right-click to open AetherDSP Settings for NR2. |
+| **RN2** | off | Enables the RN2 noise reduction algorithm. |
+| **NR4** | off | Enables the NR4 noise reduction algorithm. Right-click to open AetherDSP Settings for NR4. |
+| **MNR** | off | Enables the MNR noise reduction algorithm. Right-click to open AetherDSP Settings for MNR. |
+| **DFNR** | off | Enables the DFNR noise reduction algorithm. Right-click to open AetherDSP Settings for DFNR. |
+| **BNR** | off | Enables the BNR noise reduction algorithm. |
+| **NRL** | off | Enables the NRL noise reduction algorithm. |
+| **NRS** | off | Enables the NRS noise reduction algorithm. |
+| **RNN** | off | Enables the RNN noise reduction algorithm. |
+| **NRF** | off | Enables the NRF noise reduction algorithm. |
+
+Not all buttons may be present; availability depends on radio series and build.
+
+## Tips
+
+- Right-clicking **NR2**, **NR4**, **MNR**, or **DFNR** opens the AetherDSP Settings dialog, where you can tune advanced parameters for that algorithm. You can also open this dialog from `Settings > AetherDSP Settings...`.
+- Multiple noise reduction buttons can be active at the same time.
+
+## Related
+
+- [VFO Panel overview](overview.md)
+- [Enable squelch from the VFO panel](enable-squelch-from-the-vfo-panel.md)

--- a/docs/features/vfo-widget/enable-rit-or-xit-offset-from-the-vfo-panel.md
+++ b/docs/features/vfo-widget/enable-rit-or-xit-offset-from-the-vfo-panel.md
@@ -1,0 +1,38 @@
+# Enable RIT or XIT offset from the VFO panel
+
+RIT (Receiver Incremental Tuning) and XIT (Transmitter Incremental Tuning) let you shift the receive or transmit frequency by a small offset without moving the main VFO. This is useful for working split-frequency contacts or compensating for a station that is slightly off your dial frequency.
+
+## Before you start
+
+- AetherSDR must be connected to the radio. The VFO panel requires a live radio connection.
+- The VFO panel for the target slice must be open and expanded. If it is collapsed to the frequency-only strip, click anywhere on it to expand it.
+
+## Steps
+
+1. Click the VFO marker flag on the spectrum display for the slice you want to adjust. The VFO panel appears anchored to the marker.
+2. Click the **X/RIT** tab inside the VFO panel.
+3. To enable receiver offset, click the **RIT** button. The button activates and the label shows the current RIT offset.
+4. To enable transmitter offset, click the **XIT** button. The button activates and the label shows the current XIT offset.
+5. With RIT or XIT active, place the mouse pointer over the corresponding button and scroll the mouse wheel to adjust the offset. Each scroll step changes the offset by 10 Hz.
+6. To disable RIT or XIT, click the active button again.
+
+## What each control does
+
+| Control | Kind | Default | Valid range | Persisted setting |
+|---|---|---|---|---|
+| RIT button + label | Toggle button | off | — | — |
+| XIT button + label | Toggle button | off | — | — |
+
+**RIT / XIT buttons + labels** — Enable receiver (RIT) or transmitter (XIT) incremental tuning for this slice. When active, the label next to each button shows the current offset value. Scroll the mouse wheel over the button to adjust the offset in 10 Hz steps. Neither setting is persisted; state reflects live radio state.
+
+## Tips
+
+- RIT and XIT offsets are independent. You can enable both at the same time to offset receive and transmit independently.
+- Scroll-wheel adjustment is 10 Hz per step. For larger offsets, scroll multiple notches.
+
+## Related
+
+- [VFO Panel overview](overview.md)
+- [Change mode from the VFO panel](change-mode-from-the-vfo-panel.md)
+- [Tune the radio by typing a frequency into the VFO panel](tune-the-radio-by-typing-a-frequency-into-the-vfo-panel.md)
+- [Collapse the VFO panel to frequency-only view](collapse-the-vfo-panel-to-frequency-only-view.md)

--- a/docs/features/vfo-widget/enable-squelch-from-the-vfo-panel.md
+++ b/docs/features/vfo-widget/enable-squelch-from-the-vfo-panel.md
@@ -1,0 +1,38 @@
+# Enable squelch from the VFO panel
+
+Squelch mutes audio for a slice when the received signal falls below a set threshold. Use this to silence background noise on FM, AM, or digital modes when no signal is present.
+
+## Before you start
+
+- AetherSDR must be connected to a FLEX-8600 radio.
+- The VFO panel for the target slice must be open. If it is not, click the VFO marker flag on the spectrum display for that slice.
+- If the VFO panel is collapsed to the frequency-only strip, click it once to expand it.
+
+## Steps
+
+1. Open the VFO panel by clicking the VFO marker flag on the spectrum display for the slice you want to configure.
+2. Click the **Audio** tab inside the VFO panel.
+3. Click the **Squelch button** to enable squelch. The button activates and squelch is applied to the slice immediately.
+4. Drag the adjacent squelch slider left or right to set the threshold. The valid range is 0–100.
+
+To disable squelch, click the **Squelch button** again.
+
+## What each control does
+
+| Control | Default | Valid range | Behavior |
+|---|---|---|---|
+| Squelch button | Off | On / Off | Enables or disables squelch for this slice. |
+| Squelch slider | — | 0–100 | Sets the squelch threshold. Higher values require a stronger signal to open the squelch. |
+
+Neither the button state nor the slider position is persisted as an AetherSDR AppSettings key — both reflect live radio state.
+
+## Tips
+
+- Set the slider just above the noise floor to prevent the audio from cutting in and out on weak signals.
+- The squelch threshold interacts with the AGC setting. If you change the AGC mode using the **AGC combo**, you may need to readjust the squelch slider.
+
+## Related
+
+- [Adjust AF gain and pan from the VFO panel](adjust-af-gain-and-pan-from-the-vfo-panel.md)
+- [Mute audio for a slice from the VFO panel](mute-audio-for-a-slice-from-the-vfo-panel.md)
+- [VFO Panel overview](overview.md)

--- a/docs/features/vfo-widget/hide-or-show-filter-edge-lines-on-the-spectrum.md
+++ b/docs/features/vfo-widget/hide-or-show-filter-edge-lines-on-the-spectrum.md
@@ -1,0 +1,35 @@
+# Hide or show filter edge lines on the spectrum
+
+The VFO panel gives you a per-slice toggle to hide or show the vertical lines that mark the edges of the receive filter passband on the spectrum display. Hiding them reduces visual clutter when you want a cleaner panadapter view.
+
+## Before you start
+
+- AetherSDR must be connected to the radio.
+- The slice you want to adjust must have a VFO marker visible on the spectrum display.
+
+## Steps
+
+1. Click the VFO marker flag on the spectrum display for the target slice. The VFO panel opens anchored to the marker.
+2. Locate the **Filter edges button** in the VFO panel.
+3. Click **Filter edges button** to toggle the filter edge lines off. Click it again to restore them.
+
+The state is saved immediately. When you reopen AetherSDR, the setting is restored to whichever state you left it in for that slice.
+
+## What each control does
+
+| Control | Default | Persisted setting |
+|---|---|---|
+| **Filter edges button** | Shown (edges visible) | `Slice{N}_FilterEdgesHidden` |
+
+`{N}` is the slice number. Each slice stores its own value independently.
+
+## Tips
+
+- The setting is per-slice. Hiding filter edges on slice 0 does not affect slice 1 or any other slice.
+- If you have collapsed the VFO panel to frequency-only view, expand it first by clicking the collapsed strip to access the **Filter edges button**.
+
+## Related
+
+- [Change the VFO marker line thickness](change-the-vfo-marker-line-thickness.md)
+- [Collapse the VFO panel to frequency-only view](collapse-the-vfo-panel-to-frequency-only-view.md)
+- [VFO Panel overview](overview.md)

--- a/docs/features/vfo-widget/mute-audio-for-a-slice-from-the-vfo-panel.md
+++ b/docs/features/vfo-widget/mute-audio-for-a-slice-from-the-vfo-panel.md
@@ -1,0 +1,33 @@
+# Mute audio for a slice from the VFO panel
+
+Silence the audio output of a single slice without changing its AF Gain setting. Use this when you want to suppress a slice temporarily and restore its previous volume with one click.
+
+## Before you start
+
+- AetherSDR must be connected to a FLEX-8600 radio.
+- The VFO panel for the target slice must be open. If it is collapsed to a frequency-only strip, click anywhere on it to expand it first.
+
+## Steps
+
+1. Click the VFO marker flag on the spectrum display for the slice you want to mute. The VFO panel opens anchored to the marker.
+2. Click **Audio** to select the Audio tab inside the VFO panel.
+3. Click **Mute**. The button activates, and audio output for the slice stops. The AF Gain slider value is not changed.
+4. To restore audio, click **Mute** again. The button deactivates and audio resumes at the previous AF Gain level.
+
+## What each control does
+
+| Control | Kind | Default | Behavior |
+|---|---|---|---|
+| Mute button (Audio tab) | Toggle button | Off | Mutes audio output for this slice without changing the AF Gain setting. Click again to unmute. |
+| AF Gain slider (Audio tab) | Slider | 100 | Sets the audio output level for this slice (0–100). Unaffected by Mute. |
+
+## Tips
+
+- Muting a slice does not reset the AF Gain slider. When you unmute, audio returns at the same level it was before.
+- If you want to silence a slice permanently rather than temporarily, drag the AF Gain slider to 0 instead.
+
+## Related
+
+- [Adjust AF gain and pan from the VFO panel](adjust-af-gain-and-pan-from-the-vfo-panel.md)
+- [Enable squelch from the VFO panel](enable-squelch-from-the-vfo-panel.md)
+- [Collapse the VFO panel to frequency-only view](collapse-the-vfo-panel-to-frequency-only-view.md)

--- a/docs/features/vfo-widget/overview.md
+++ b/docs/features/vfo-widget/overview.md
@@ -1,0 +1,103 @@
+# VFO Panel overview
+
+The VFO Panel is a floating, per-slice control panel anchored to the VFO marker flag on the spectrum display. It gives you quick access to the most frequently used slice settings — mode, filter presets, antenna selection, audio controls, AGC, noise reduction, RIT/XIT, and DAX assignment — without leaving the spectrum view.
+
+## Before you start
+
+- AetherSDR must be connected to a FLEX-8600 radio.
+- At least one slice must be active on the panadapter.
+
+## How it works
+
+Click the VFO marker flag on the spectrum display for any slice. The panel appears anchored to the left of the marker and flips right automatically if it would be clipped by the window edge.
+
+The panel is divided into tabs — **Mode**, **Audio**, **DSP**, **X/RIT**, and **DAX** — plus a header row that is always visible. Controls in the header row apply regardless of which tab is active.
+
+When collapsed, the panel shrinks to a compact frequency-only strip. Scroll-wheel tuning still works in collapsed mode. Click anywhere on the collapsed strip to expand it again, or click the TX badge to toggle the transmit slice assignment.
+
+### Header row
+
+The header row sits above the tabs and is always visible.
+
+| Control | What it does |
+|---|---|
+| RX antenna button | Opens the antenna selection menu for the receive antenna of this slice. |
+| TX antenna button | Opens the antenna selection menu for the transmit antenna of this slice. |
+| Frequency display | Shows the current slice frequency. Click once to begin direct frequency entry; type a value in MHz and press Enter or Tab to apply. Scroll-wheel over the frequency display tunes by the current step size. |
+| Filter width label | Shows the current filter bandwidth. Click to cycle through the filter preset buttons in the Mode tab. |
+| TX badge | Shown in red when this slice is the active transmit slice. In collapsed mode, click the badge to toggle TX assignment. |
+| SPLIT badge | Shown in amber when TX is assigned to a different slice than the active receive slice. |
+
+### Mode tab
+
+| Control | Default | Valid values | Persisted key |
+|---|---|---|---|
+| Mode combo | USB | USB, LSB, CW, CWL, AM, SAM, DIGU, DIGL, FM, NFM, DFM, RTTY | — |
+| Filter preset buttons | — | — | `FilterPresets` |
+
+Right-click a filter preset button to save the current filter width into that slot. Custom low and high filter edges can be saved per slot the same way.
+
+### Audio tab
+
+| Control | Default | Valid range | Persisted key |
+|---|---|---|---|
+| AF Gain slider | 100 | 0–100 | — |
+| Pan slider | 50 | 0–100 | — |
+| Mute button | off | — | — |
+| Squelch button + slider | off | 0–100 | — |
+| AGC combo | FAST | FAST, MED, SLOW, OFF | — |
+
+The Pan slider center position (50) is stereo centre. Double-click the Pan slider to reset it to centre. Audio controls reflect live radio state and are not persisted by AetherSDR.
+
+### DSP tab
+
+| Control | Default | Notes |
+|---|---|---|
+| NR / NR2 / RN2 / NR4 / MNR / DFNR / BNR / NRL / NRS / RNN / NRF buttons | off | Button availability depends on radio series and build. Right-click NR2, NR4, MNR, or DFNR to open the AetherDSP Settings dialog for that algorithm. |
+
+### X/RIT tab
+
+| Control | Default | Notes |
+|---|---|---|
+| RIT button + label | off | Enables receiver incremental tuning. The label shows the current offset. Scroll-wheel adjusts in 10 Hz steps. |
+| XIT button + label | off | Enables transmitter incremental tuning. The label shows the current offset. Scroll-wheel adjusts in 10 Hz steps. |
+
+### DAX tab
+
+| Control | Default | Valid values | Persisted key |
+|---|---|---|---|
+| DAX channel combo | Off | Off, 1–8 | — |
+
+### Display controls
+
+These controls affect how the slice appears on the spectrum display. They are persisted individually per slice (where `{N}` is the slice number).
+
+| Control | Default | Valid values | Persisted key |
+|---|---|---|---|
+| Marker thickness button | 1 px | Off, 1 px, 3 px | `Slice{N}_MarkerWidth` |
+| Filter edges button | shown | shown / hidden | `Slice{N}_FilterEdgesHidden` |
+| Collapse toggle | expanded | expanded / collapsed | `SliceFlagCollapsed_{N}` |
+
+Clicking the slice badge in the header row collapses the panel. Clicking anywhere on the collapsed strip expands it.
+
+## Tips
+
+- In collapsed mode, scroll-wheel anywhere over the strip tunes the slice by the current step size.
+- Momentum (inertial) scroll events on macOS are ignored to prevent unintended tuning after a trackpad gesture ends.
+- The panel flips to the right side of the marker automatically if displaying on the left would clip it at the window edge.
+
+## Related
+
+- [Tune the radio by typing a frequency into the VFO panel](tune-the-radio-by-typing-a-frequency-into-the-vfo-panel.md)
+- [Change mode from the VFO panel](change-mode-from-the-vfo-panel.md)
+- [Apply a filter width preset from the VFO panel](apply-a-filter-width-preset-from-the-vfo-panel.md)
+- [Set a custom filter edge from the VFO panel](set-a-custom-filter-edge-from-the-vfo-panel.md)
+- [Adjust AF gain and pan from the VFO panel](adjust-af-gain-and-pan-from-the-vfo-panel.md)
+- [Mute audio for a slice from the VFO panel](mute-audio-for-a-slice-from-the-vfo-panel.md)
+- [Enable squelch from the VFO panel](enable-squelch-from-the-vfo-panel.md)
+- [Enable noise reduction from the VFO panel](enable-noise-reduction-from-the-vfo-panel.md)
+- [Enable RIT or XIT offset from the VFO panel](enable-rit-or-xit-offset-from-the-vfo-panel.md)
+- [Assign a DAX channel from the VFO panel](assign-a-dax-channel-from-the-vfo-panel.md)
+- [Change the VFO marker line thickness](change-the-vfo-marker-line-thickness.md)
+- [Hide or show filter edge lines on the spectrum](hide-or-show-filter-edge-lines-on-the-spectrum.md)
+- [Collapse the VFO panel to frequency-only view](collapse-the-vfo-panel-to-frequency-only-view.md)

--- a/docs/features/vfo-widget/set-a-custom-filter-edge-from-the-vfo-panel.md
+++ b/docs/features/vfo-widget/set-a-custom-filter-edge-from-the-vfo-panel.md
@@ -1,0 +1,39 @@
+# Set a custom filter edge from the VFO panel
+
+The VFO panel's filter preset buttons let you save and recall filter widths quickly. Right-clicking a preset button opens a dialog where you can set exact low and high filter edge values for that slot. Use this when the built-in preset widths do not match your operating needs.
+
+## Before you start
+
+- AetherSDR must be connected to a FLEX-8600 radio.
+- The VFO panel must be open. If it is not visible, click the VFO marker flag on the spectrum display for the slice you want to adjust.
+- The VFO panel must not be collapsed. If it shows only a frequency strip, click anywhere on it to expand it.
+- Open the **Mode** tab inside the VFO panel so the filter preset buttons are visible.
+
+## Steps
+
+1. Click the VFO marker flag on the spectrum display to open the VFO panel for the target slice.
+2. In the VFO panel, click the **Mode** tab to show the mode selector and filter preset buttons.
+3. Right-click the filter preset button whose edges you want to customize. A context menu or dialog appears.
+4. Enter the desired low edge and high edge values in the fields provided.
+5. Confirm the entry to save the custom edges into that preset slot.
+
+The preset button now applies your custom filter edges when clicked. The values are persisted in `FilterPresets`.
+
+## What each control does
+
+| Control | Behavior | Default | Setting key |
+|---|---|---|---|
+| Filter preset buttons (Mode tab) | Applies a saved filter width preset when clicked. Right-click to save the current filter width or set custom lo/hi edges for that slot. | — | `FilterPresets` |
+| Filter width label | Shows the current filter bandwidth. Click to cycle through filter preset buttons in the Mode tab. | — | — |
+| Filter edges button | Toggles the filter edge lines on the spectrum passband display. | shown | `Slice{N}_FilterEdgesHidden` |
+
+## Tips
+
+- To verify the active filter edges on the spectrum, confirm that the filter edges button is in its default shown state. If the edge lines are hidden, toggle the filter edges button to make them visible again.
+- Right-clicking a preset button saves the *current* filter width into that slot as an alternative to typing edge values manually. Use this for a quick capture of a filter you have already dialed in.
+
+## Related
+
+- [Apply a filter width preset from the VFO panel](apply-a-filter-width-preset-from-the-vfo-panel.md)
+- [Hide or show filter edge lines on the spectrum](hide-or-show-filter-edge-lines-on-the-spectrum.md)
+- [Change mode from the VFO panel](change-mode-from-the-vfo-panel.md)

--- a/docs/features/vfo-widget/tune-the-radio-by-typing-a-frequency-into-the-vfo-panel.md
+++ b/docs/features/vfo-widget/tune-the-radio-by-typing-a-frequency-into-the-vfo-panel.md
@@ -1,0 +1,38 @@
+# Tune the radio by typing a frequency into the VFO panel
+
+Direct frequency entry lets you jump to an exact frequency without clicking around the panadapter. Type a value in MHz into the VFO panel's frequency display and press Enter.
+
+## Before you start
+
+- AetherSDR must be connected to your FLEX-8600 radio.
+- The VFO panel for the target slice must be open. If it is not visible, click the VFO marker flag for that slice on the spectrum display.
+
+## Steps
+
+1. Click the **Frequency display** once. The display enters direct entry mode.
+2. Type the desired frequency in MHz.
+3. Press **Enter** or **Tab** to apply. The slice retunes immediately.
+
+## What each control does
+
+| Control | Behavior | Default | Persisted key |
+|---|---|---|---|
+| **Frequency display** | Shows the current slice frequency. Click once to begin direct entry; type MHz and press Enter or Tab to apply. Scroll the mouse wheel over the display to step-tune up or down by the current step size. | — | — |
+| **Collapse toggle** | Collapses the VFO panel to a compact frequency-only strip. In collapsed mode, scrolling anywhere on the strip tunes by the current step size. | Expanded | `SliceFlagCollapsed_{N}` |
+
+## Tips
+
+- If the panel is collapsed to the frequency-only strip, click anywhere on it to expand it so the **Frequency display** is accessible for direct entry.
+- The scroll wheel also tunes the slice when the pointer is over the **Frequency display**, stepping by the slice's current step size. On macOS, inertial scroll events are ignored to prevent unintended tuning after a gesture ends.
+
+## Troubleshooting
+
+- **Typing has no effect** — Check that the slice is not locked. A locked slice ignores tune commands. Unlock it before entering a frequency.
+- **The VFO panel is not visible** — Click the VFO marker flag for the desired slice on the spectrum display to open the panel.
+
+## Related
+
+- [VFO Panel overview](overview.md)
+- [Collapse the VFO panel to frequency-only view](collapse-the-vfo-panel-to-frequency-only-view.md)
+- [Change mode from the VFO panel](change-mode-from-the-vfo-panel.md)
+- [Enable RIT or XIT offset from the VFO panel](enable-rit-or-xit-offset-from-the-vfo-panel.md)

--- a/docs/features/wave/adjust-waveform-amplitude-zoom.md
+++ b/docs/features/wave/adjust-waveform-amplitude-zoom.md
@@ -1,0 +1,43 @@
+# Adjust waveform amplitude zoom
+
+The Zoom slider in the Waveform applet scales the amplitude axis of the waveform display. Increasing zoom stretches small signals vertically so they are easier to read; decreasing it prevents clipping artifacts from obscuring the trace on loud signals.
+
+## Before you start
+
+- The Waveform applet must be visible. If it is not, click the WAVE tray button in the right sidebar to show it.
+- The settings drawer must be open. If only the waveform trace is visible with no controls below it, double-click the waveform display to open the drawer.
+
+## Steps
+
+1. Double-click the waveform display to open the settings drawer if it is not already open.
+2. Locate the Zoom row in the settings drawer.
+3. Drag the Zoom slider left to decrease zoom or right to increase zoom. The readout to the right of the slider updates immediately, showing the current value as a multiplier (for example, `1.7x`).
+4. Release the slider. The new value is saved automatically to `WaveApplet_ZoomPercent`.
+
+## What each control does
+
+| Control | Default | Valid range | Persisted key |
+|---|---|---|---|
+| Zoom | 170 (1.7x) | 100–600 (displayed as 1.0x–6.0x) | `WaveApplet_ZoomPercent` |
+
+The slider value is an integer percentage. The waveform display divides it by 100 to produce the multiplier shown in the readout. A value of 100 means no zoom (1.0x); 600 is maximum zoom (6.0x).
+
+## Tips
+
+- At high zoom levels, signals near full scale will produce clipping highlights (red column emphasis and a CLIP N counter in the header). If you see frequent clipping indicators after raising zoom, reduce the value until the trace fits within the display without hitting the edges.
+- The zoom setting applies equally to RX and TX paths. The direction tint (cool for RX, warm for TX) still distinguishes which path is active regardless of zoom level.
+- To inspect a transient at a higher zoom without missing it in real time, pause the display first by single-clicking the waveform, then adjust zoom while the snapshot is frozen.
+
+## Troubleshooting
+
+- **The settings drawer is not visible** — Double-click the waveform display to toggle it open. The drawer is below the waveform trace.
+- **The Zoom slider snaps back after dragging** — This can happen if no audio is arriving and the display is showing the no-audio placeholder. The slider value is still saved; it takes effect as soon as audio resumes.
+- **Zoom resets after restarting AetherSDR** — Verify the value is being persisted. If the application closed abnormally, the `WaveApplet_ZoomPercent` setting may not have been written. Set the slider to the desired value after a clean launch.
+
+## Related
+
+- [Waveform overview](overview.md)
+- [Monitor TX or RX audio on the waveform display](monitor-tx-or-rx-audio-on-the-waveform-display.md)
+- [Pause the waveform to inspect a transient](pause-the-waveform-to-inspect-a-transient.md)
+- [Switch the waveform view mode (Scope, Envelope, History, Bands)](switch-the-waveform-view-mode-scope-envelope-history-bands.md)
+- [Set the waveform refresh rate to reduce CPU load](set-the-waveform-refresh-rate-to-reduce-cpu-load.md)

--- a/docs/features/wave/monitor-tx-or-rx-audio-on-the-waveform-display.md
+++ b/docs/features/wave/monitor-tx-or-rx-audio-on-the-waveform-display.md
@@ -1,0 +1,49 @@
+# Monitor TX or RX audio on the waveform display
+
+The Waveform applet displays a live time-domain view of the active TX or RX audio path. Use it to spot clipping, dropouts, and audio level problems without leaving the main window.
+
+## Before you start
+
+- AetherSDR must be running. A radio connection is not required — the applet displays audio from the local audio engine.
+- The applet panel must be visible. If it is hidden, enable it via `View > Applet Panel`.
+
+## Steps
+
+1. Locate the WAVE tray button in the right sidebar's top row of tray buttons.
+2. Click WAVE to show the Waveform applet. Click it again to hide it.
+3. Watch the waveform display. The trace is tinted cool when monitoring RX audio and warm when monitoring TX audio — no label reading required.
+4. Check the header readout for the current direction (RX or TX), RMS level in dBFS, and peak level in dBFS.
+5. If no audio has arrived within one second, the display shows a "no RX audio" or "no TX audio" placeholder instead of an empty trace.
+6. To open the settings drawer, double-click anywhere on the waveform display. Double-click again to close it.
+7. In the settings drawer, use the View combo box to choose a visualization: **Scope**, **Envelope**, **History**, or **Bands**. The default is **Scope**.
+8. Use the Zoom slider to scale the amplitude axis. The default is 1.7x (range 1.0x–6.0x). Drag right to stretch small signals; at high zoom values, clipping artifacts appear sooner.
+9. Use the FPS slider to set how often the display repaints (range 5–30 Hz, default 24). Lower values reduce CPU load.
+
+## What each control does
+
+| Control | Default | Valid range | Persisted key | Behavior |
+|---|---|---|---|---|
+| View | Scope | Scope, Envelope, History, Bands | `WaveApplet_ViewMode` | Selects the visualization mode. Scope shows min/max waveform and RMS lines. Envelope shows a peak/RMS filled area. History shows horizontal level bars. Bands shows frequency band bars. |
+| Zoom | 1.7x (170) | 1.0x–6.0x (100–600) | `WaveApplet_ZoomPercent` | Scales the amplitude axis vertically. |
+| FPS | 24 | 5–30 Hz | `WaveApplet_RefreshRateHz` | Controls repaint frequency. |
+| Click on display | Live | Live / Paused | — | Toggles pause. A PAUSED badge appears in the footer while the display is frozen. |
+| Double-click on display | — | — | — | Toggles the settings drawer open or closed. |
+
+## Tips
+
+- When clipping occurs, affected columns are highlighted and a CLIP N counter appears in the header. Reduce your audio drive level or lower the Zoom value to bring the signal back within range.
+- Click once on the waveform to freeze a snapshot when you notice a transient. Click again to resume the live view.
+- The settings drawer opens in the expanded state each time you launch AetherSDR.
+
+## Troubleshooting
+
+- **The display shows "no RX audio" or "no TX audio"** — No scope samples have arrived in the last second. Verify that audio is flowing through the relevant path and that the correct audio device is selected in `Settings > Radio Setup...`.
+- **The WAVE tray button is missing** — The applet panel may be hidden. Enable it via `View > Applet Panel`. If the panel is visible but WAVE is absent, use `View > Reset Applet Order` to restore the default applet layout.
+
+## Related
+
+- [Waveform overview](overview.md)
+- [Pause the waveform to inspect a transient](pause-the-waveform-to-inspect-a-transient.md)
+- [Switch the waveform view mode (Scope, Envelope, History, Bands)](switch-the-waveform-view-mode-scope-envelope-history-bands.md)
+- [Adjust waveform amplitude zoom](adjust-waveform-amplitude-zoom.md)
+- [Set the waveform refresh rate to reduce CPU load](set-the-waveform-refresh-rate-to-reduce-cpu-load.md)

--- a/docs/features/wave/pause-the-waveform-to-inspect-a-transient.md
+++ b/docs/features/wave/pause-the-waveform-to-inspect-a-transient.md
@@ -1,0 +1,45 @@
+# Pause the waveform to inspect a transient
+
+Single-clicking the waveform display freezes a snapshot of the current audio buffer so you can examine a transient, clipping event, or dropout without the trace continuing to scroll.
+
+## Before you start
+
+- The Waveform applet must be visible. If it is not, click the WAVE tray button in the right sidebar to open it.
+- Audio must be flowing (RX or TX) so there is something worth freezing. If no samples have arrived within 1 second, the display shows a "no RX audio" or "no TX audio" placeholder instead of a trace.
+
+## Steps
+
+1. Watch the waveform display for the transient you want to examine.
+2. Single-click anywhere on the waveform display at the moment the event appears.
+3. Confirm the display is frozen: a **PAUSED** badge appears in the footer of the waveform display.
+4. Examine the frozen trace. The header continues to show the RX/TX direction, RMS dBFS, and PK dBFS values that were captured at the moment of the click.
+5. Single-click the waveform display again to resume live updates. The **PAUSED** badge disappears.
+
+## What each control does
+
+| Control | Behavior | Default | Valid range | Setting key |
+|---|---|---|---|---|
+| Click on display | Toggles pause: freezes a buffer snapshot on first click; resumes live display on second click. | Live | Live / Paused | — |
+| View | Selects the visualization mode shown while paused. | Scope | Scope, Envelope, History, Bands | `WaveApplet_ViewMode` |
+| Zoom | Scales the amplitude axis. Higher values stretch small signals vertically, making subtle transients easier to see while paused. | 1.7x (170) | 100–600 (1.0x–6.0x) | `WaveApplet_ZoomPercent` |
+| FPS | Controls repaint rate while live. Has no effect while paused. | 24 | 5–30 Hz | `WaveApplet_RefreshRateHz` |
+
+## Tips
+
+- The click is disambiguated from a double-click by a short interval. If the display does not freeze on your first click, click once and wait rather than clicking rapidly.
+- Double-clicking opens or closes the settings drawer instead of pausing. If you accidentally open the drawer, double-click again to close it, then single-click to pause.
+- Increasing Zoom before pausing can make low-level transients more visible in the frozen frame.
+- The TX path is tinted differently from the RX path, so you can confirm which audio direction the frozen snapshot represents without reading the header.
+
+## Troubleshooting
+
+- **Click does not pause the display** — Make sure you are clicking once on the waveform area itself, not on the settings drawer below it. A rapid second click will immediately resume the display; click once and pause before clicking again.
+- **PAUSED badge appears but the trace is blank** — The buffer was empty at the moment you clicked. This happens when no audio has arrived within the last second. Resume live mode, wait for audio to appear, then click again.
+- **Display resumes on its own** — Pausing only freezes the visual display; a reconnect or audio engine reset clears the buffer and restores the live view.
+
+## Related
+
+- [Waveform overview](overview.md)
+- [Monitor TX or RX audio on the waveform display](monitor-tx-or-rx-audio-on-the-waveform-display.md)
+- [Adjust waveform amplitude zoom](adjust-waveform-amplitude-zoom.md)
+- [Switch the waveform view mode (Scope, Envelope, History, Bands)](switch-the-waveform-view-mode-scope-envelope-history-bands.md)

--- a/docs/features/wave/set-the-waveform-refresh-rate-to-reduce-cpu-load.md
+++ b/docs/features/wave/set-the-waveform-refresh-rate-to-reduce-cpu-load.md
@@ -1,0 +1,35 @@
+# Set the waveform refresh rate to reduce CPU load
+
+The Waveform applet repaints at up to 30 frames per second by default. On slower systems, lowering the frame rate reduces CPU usage with no effect on the audio data being monitored.
+
+## Before you start
+
+- The WAVE applet must be visible in the applet panel. If it is not, click the WAVE tray button in the right sidebar to show it.
+- The settings drawer must be open. If you see only the waveform display, double-click the display to open the drawer.
+
+## Steps
+
+1. Double-click the waveform display to open the settings drawer.
+2. Locate the FPS row at the bottom of the drawer.
+3. Drag the FPS slider left to decrease the frame rate or right to increase it. The current value is shown to the right of the slider in the format `N fps`.
+4. Release the slider. The new rate takes effect immediately and is saved automatically to `WaveApplet_RefreshRateHz`.
+
+## What each control does
+
+| Control | Default | Valid range | Persisted key |
+|---|---|---|---|
+| FPS | 24 Hz | 5–30 Hz | `WaveApplet_RefreshRateHz` |
+
+Lower values reduce how often the waveform repaints. Higher values give smoother motion. The setting has no effect on audio capture or level accuracy.
+
+## Tips
+
+- A value of 5–10 fps is sufficient for monitoring average levels and spotting clipping. Use higher values only when you need to track fast transients visually.
+- The FPS slider uses a single step of 5 and a page step of 10, so pressing the arrow keys or Page Up/Page Down on the slider moves it in those increments.
+- Reducing FPS does not affect the other settings in the drawer. View mode (`WaveApplet_ViewMode`) and zoom (`WaveApplet_ZoomPercent`) remain independent.
+
+## Related
+
+- [Waveform overview](overview.md)
+- [Monitor TX or RX audio on the waveform display](monitor-tx-or-rx-audio-on-the-waveform-display.md)
+- [Adjust waveform amplitude zoom](adjust-waveform-amplitude-zoom.md)

--- a/docs/features/wave/switch-the-waveform-view-mode-scope-envelope-history-bands.md
+++ b/docs/features/wave/switch-the-waveform-view-mode-scope-envelope-history-bands.md
@@ -1,0 +1,45 @@
+# Switch the waveform view mode (Scope, Envelope, History, Bands)
+
+The Waveform applet offers four visualization modes for the active audio path. Switching modes lets you choose the representation that best suits your monitoring task — for example, Bands to spot frequency imbalance in a TX signal, or Scope for a traditional time-domain trace.
+
+## Before you start
+
+- The WAVE applet must be visible in the applet panel. If it is not, click the WAVE tray button in the right sidebar to show it.
+- The settings drawer must be open. If you see only the waveform display with no controls beneath it, double-click the waveform display to open the drawer.
+
+## Steps
+
+1. Double-click the waveform display to open the settings drawer if it is not already open.
+2. In the settings drawer, locate the **View:** label on the first row.
+3. Click the combo box to the right of **View:**.
+4. Select one of the four options: **Scope**, **Envelope**, **History**, or **Bands**.
+
+The display updates immediately. The selection is saved to `WaveApplet_ViewMode` and restored on the next launch.
+
+## What each control does
+
+| Control | Default | Valid values | Persisted key | Behavior |
+|---------|---------|--------------|---------------|----------|
+| **View:** combo box | Scope | Scope, Envelope, History, Bands | `WaveApplet_ViewMode` | Selects the visualization mode. Scope shows min/max and RMS lines. Envelope shows a peak/RMS filled area. History shows horizontal level bars. Bands shows frequency band bars. |
+| **Zoom:** slider | 1.7x | 1.0x – 6.0x (100–600) | `WaveApplet_ZoomPercent` | Scales the amplitude axis. Higher values stretch small signals vertically. |
+| **FPS:** slider | 24 fps | 5–30 Hz | `WaveApplet_RefreshRateHz` | Controls repaint frequency. Lower values reduce CPU load. |
+
+## Tips
+
+- **Bands** mode uses a Goertzel filter to derive frequency band bars. It is useful for checking whether TX audio energy is distributed across the expected frequency range.
+- **History** mode displays horizontal level bars accumulated over time, which makes it easier to see sustained level trends than a momentary trace.
+- If the display shows a "no RX audio" or "no TX audio" message, no scope samples have arrived within the last second. The view mode setting is still applied and will take effect as soon as audio resumes.
+- Single-clicking the waveform display toggles pause. If the display appears frozen, click it once to resume live updates. A **PAUSED** badge in the footer confirms the paused state.
+
+## Troubleshooting
+
+- **The View: combo box is not visible** — The settings drawer is closed. Double-click the waveform display to toggle it open.
+- **The selected mode does not persist after restart** — Confirm AetherSDR has write access to its settings storage. If the issue repeats, check that no other AetherSDR instance is running simultaneously and overwriting `WaveApplet_ViewMode` on exit.
+
+## Related
+
+- [Waveform overview](overview.md)
+- [Monitor TX or RX audio on the waveform display](monitor-tx-or-rx-audio-on-the-waveform-display.md)
+- [Adjust waveform amplitude zoom](adjust-waveform-amplitude-zoom.md)
+- [Pause the waveform to inspect a transient](pause-the-waveform-to-inspect-a-transient.md)
+- [Set the waveform refresh rate to reduce CPU load](set-the-waveform-refresh-rate-to-reduce-cpu-load.md)

--- a/docs/getting-started/setup/fix-tune-not-working-after-upgrading-to-firmware-4-2-configure-direct-tgxl-connection.md
+++ b/docs/getting-started/setup/fix-tune-not-working-after-upgrading-to-firmware-4-2-configure-direct-tgxl-connection.md
@@ -1,0 +1,43 @@
+# Fix TUNE not working after upgrading to firmware 4.2 (configure direct TGXL connection)
+
+Firmware 4.2 broke the radio's internal path for sending the autotune command to the Tuner Genius XL. Since AetherSDR v0.9.2.1, the TUNE button can bypass the radio firmware entirely by connecting to the TGXL directly on port 9010. This page explains how to configure that direct connection.
+
+## Before you start
+
+- AetherSDR v0.9.2.1 or later is installed.
+- Your TGXL is powered on and reachable from the computer running AetherSDR (not just from the radio).
+- You know the TGXL's IP address.
+- You are connected to the radio. The TUN tray button is visible in the right sidebar (the Tuner applet appears only when a Tuner Genius XL is detected).
+
+## Steps
+
+1. Open `Settings > Radio Setup...`.
+2. Select the **Tuner** tab.
+3. Enter your TGXL's IP address and confirm the port is set to **9010**.
+4. Click **Apply** or **OK** to save.
+5. In the right sidebar, click the **TUN** tray button to open the Tuner applet.
+6. Click **TUNE**.
+
+The button turns red and reads **TUNING...** while the autotune sweep runs. When complete, it flashes **SWR x.xx** for approximately 2.5 seconds, then returns to **TUNE**.
+
+## Tips
+
+- When a direct connection is active, AetherSDR sends the native `autotune` command directly to the TGXL over port 9010, bypassing the `tgxl autotune handle=<H>` path through the radio firmware that broke in 4.2.
+- If no direct connection is configured, the TUNE button falls back to the radio firmware path. On firmware 4.2 that path may not work; configuring the direct connection is the reliable fix.
+- With a direct connection active, the C1, L, and C2 relay bars also enable mousewheel adjustment, and the ANT 1 / ANT 2 / ANT 3 antenna switch row becomes visible if your TGXL has a 3x1 switch.
+
+## Troubleshooting
+
+- **TUNE button shows TUNING... but never returns an SWR result** — The TGXL may not be reachable on port 9010 from your computer. Verify the IP address in `Settings > Radio Setup...` under the Tuner tab, and confirm there is no firewall blocking port 9010 between your computer and the TGXL.
+- **TUN tray button is not visible** — The Tuner applet is hidden until AetherSDR detects a Tuner Genius XL. Confirm the TGXL is powered on and the radio recognises it before opening the applet.
+- **SWR result flashes a very high value after tuning** — The post-tune SWR capture window is 400 ms. If the TGXL reports the settled SWR outside that window, the displayed value may not reflect the final match. Try the tune again; the value shown is the lowest SWR seen in the capture window.
+
+## Related
+
+- [Connect TGXL, PGXL or Antenna Genius by IP](connect-tgxl-pgxl-or-antenna-genius-by-ip.md)
+- [Run an autotune on the external TGXL](../../features/tuner/run-an-autotune-on-the-external-tgxl.md)
+- [Read SWR immediately after a tune](../../features/tuner/read-swr-immediately-after-a-tune.md)
+- [Put the tuner in OPERATE, BYPASS, or STANDBY](../../features/tuner/put-the-tuner-in-operate-bypass-or-standby.md)
+- [Fine-tune the C1/L/C2 relays with the mousewheel](../../features/tuner/fine-tune-the-c1-l-c2-relays-with-the-mousewheel.md)
+- [Switch between three antennas on a TGXL 3x1](../../features/tuner/switch-between-three-antennas-on-a-tgxl-3x1.md)
+- [Tuner overview](../../features/tuner/overview.md)

--- a/docs/getting-started/setup/recover-tgxl-tune-on-firmware-4-2-by-configuring-a-direct-connection.md
+++ b/docs/getting-started/setup/recover-tgxl-tune-on-firmware-4-2-by-configuring-a-direct-connection.md
@@ -1,0 +1,47 @@
+# Recover TGXL TUNE on firmware 4.2 by configuring a direct connection
+
+FlexRadio firmware 4.2 broke the radio-side `tgxl autotune` command path. Configuring a direct TCP connection from AetherSDR to the TGXL restores the TUNE button by sending the autotune command directly to the TGXL instead of routing it through the radio.
+
+## Before you start
+
+- AetherSDR must be connected to your FLEX-8600 radio.
+- Your TGXL must be powered on and reachable on the network from the machine running AetherSDR.
+- Know the TGXL's IP address. If the radio has already discovered the TGXL, AetherSDR will pre-fill it for you.
+
+## Steps
+
+1. Click `Settings > Radio Setup...` to open the Radio Setup dialog.
+2. Click the `Peripherals` tab.
+3. Locate the TGXL row. If the IP address field is empty, enter the TGXL's IP address. The default port is `9010`; leave it unchanged unless your network requires a different port.
+4. Click `Connect` in the TGXL row.
+5. Verify the button changes to `Disconnect`, indicating the direct TCP connection is active.
+6. Close the dialog. The TUNE button now sends the autotune command directly to the TGXL.
+
+AetherSDR saves the IP and port to `TGXL_ManualIp` and `TGXL_ManualPort` on a successful connect and will reconnect automatically on the next startup.
+
+## What each control does
+
+| Control | Behavior | Default | Setting key |
+|---|---|---|---|
+| IP address field (TGXL) | IP address of the TGXL on your network. Pre-filled with the radio-discovered address if available. | — | `TGXL_ManualIp` |
+| Port field (TGXL) | TCP port for the direct TGXL connection. | `9010` | `TGXL_ManualPort` |
+| `Connect` / `Disconnect` (TGXL) | Opens or closes the direct TCP connection to the TGXL. When connected, TUNE sends the autotune command directly to the TGXL. | Connect | — |
+
+## Tips
+
+- The TGXL drives radio PTT through its hardware interlock cable. No additional PTT configuration in AetherSDR is needed for tuning to work once the direct connection is active.
+- If the radio has already discovered the TGXL on the LAN, the IP address field is pre-filled. You only need to click `Connect`.
+- The saved `TGXL_ManualIp` and `TGXL_ManualPort` values persist across restarts, so you only need to perform this setup once.
+
+## Troubleshooting
+
+- **`Connect` button does not change to `Disconnect`** — The TGXL is not reachable at the entered IP and port. Confirm the TGXL is powered on, check that port `9010` is not blocked by a firewall, and verify the IP address is correct.
+- **TUNE still does not work after connecting** — Confirm the `Disconnect` label is shown in the TGXL row, which confirms the direct connection is active. If the button reverted to `Connect`, the connection dropped; check network stability and reconnect.
+- **IP address field is empty and the radio has not discovered the TGXL** — Enter the TGXL's IP address manually. You can find it in your router's DHCP table or on the TGXL's front panel.
+
+## Related
+
+- [Connect TGXL, PGXL or Antenna Genius by IP](connect-tgxl-pgxl-or-antenna-genius-by-ip.md)
+- [Fix TUNE not working after upgrading to firmware 4.2 (configure direct TGXL connection)](fix-tune-not-working-after-upgrading-to-firmware-4-2-configure-direct-tgxl-connection.md)
+- [Set per-band TX max power and tune mode](../../features/radio-setup/set-per-band-tx-max-power-and-tune-mode.md)
+- [Radio Setup overview](../../features/radio-setup/overview.md)

--- a/docs/reference/menu-actions/submit-your-idea.md
+++ b/docs/reference/menu-actions/submit-your-idea.md
@@ -1,0 +1,38 @@
+# Submit your idea... 💡
+
+This page explains how to use `Help > Submit your idea... 💡` to report a bug or propose a feature request using an AI assistant. The workflow copies a pre-filled prompt to your clipboard and opens the AI provider's website so the AI can help you check for duplicates and structure your submission.
+
+## Before you start
+
+- You need an active internet connection. The menu item checks GitHub for a newer AetherSDR release before opening the dialog.
+- You need an account with at least one of the supported AI providers: Claude, ChatGPT, Gemini, Grok, or Perplexity.
+
+## Steps
+
+1. Click `Help > Submit your idea... 💡`.
+2. If AetherSDR detects that a newer release is available, a warning is displayed. Review it before continuing, as your issue may already be resolved in the newer version.
+3. The AI-Assisted Issue Reporter dialog opens. Read the step-by-step instructions shown in the dialog.
+4. Click the button for your preferred AI provider: **Claude**, **ChatGPT**, **Gemini**, **Grok**, or **Perplexity**.
+5. AetherSDR copies a pre-filled prompt to your clipboard and opens the selected provider's website in your default browser.
+6. In the browser, paste the clipboard contents into the AI chat input and submit it.
+7. The AI checks the AetherSDR GitHub repository for duplicate issues and produces a structured bug report or feature request. Review the AI's output, then use it to open a GitHub issue.
+
+## What each control does
+
+| Button | Action |
+|---|---|
+| **Claude** | Copies the pre-filled prompt to the clipboard and opens the Claude website. |
+| **ChatGPT** | Copies the pre-filled prompt to the clipboard and opens the ChatGPT website. |
+| **Gemini** | Copies the pre-filled prompt to the clipboard and opens the Gemini website. |
+| **Grok** | Copies the pre-filled prompt to the clipboard and opens the Grok website. |
+| **Perplexity** | Copies the pre-filled prompt to the clipboard and opens the Perplexity website. |
+
+## Tips
+
+- The prompt instructs the AI to search for existing GitHub issues before drafting a new one. Let the AI complete that step before copying its output into a new issue.
+- If the version warning appears, consider updating AetherSDR first and checking whether the bug or missing feature is already addressed.
+
+## Related
+
+- [Contributing to AetherSDR](contributing-to-aethersdr.md)
+- [AetherSDR Help](aethersdr-help.md)


### PR DESCRIPTION
## Summary

New pages generated after rebuilding \`topics.json\` from the updated catalog (not run since before v0.9.1).

- **6 pages** — ShackSwitchApplet (new in v0.9.4, never documented)
- **14 pages** — VfoWidget (tasks added to catalog but topics never rebuilt)
- **32 pages** — Other features with catalog entries but missing topics: ClientEq extras, ClientGate, ClientTube, ClientLevelMeter, Wave applet, plus a few troubleshooting/setup pages

52 files total, all new (`create mode`), no modifications to existing docs.

## Test plan
- [x] Spot-check `features/shack-switch/overview.md` and a task page
- [x] Spot-check `features/vfo-widget/overview.md`
- [x] Verify sidebar navigation picks up the new sections