### PR TITLE
docs: add 7 new feature pages for v26.5.2.1 dialogs

### DIFF
--- a/docs/features/atu-pre-tune/overview.md
+++ b/docs/features/atu-pre-tune/overview.md
@@ -1,0 +1,34 @@
+# ATU Pre-Tune overview
+
+Run an automatic sweep across selected HF and 6m bands, triggering the radio's built-in ATU (Antenna Tuning Unit) at each center frequency. This ensures your tuner has a valid tuning solution stored for every band you plan to use, reducing the chance of high SWR when you change frequencies during an operating session.
+
+## How it works
+
+The ATU Pre-Tune feature steps the active TX slice through a calculated set of center frequencies across the bands you select. At each frequency, AetherSDR sends an `atu start` command to the radio and waits for the radio to report completion (via `atuStateChanged`) before moving to the next point. Band edges are taken from the active region's band plan so the sweep stays within legal and practical frequency limits.
+
+## Before you start
+
+- A radio must be connected. The Pre-Tune dialog requires an active radio connection to send ATU commands.
+- The radio must have an internal or external ATU available and functional.
+
+## Opening the dialog
+
+- **Menu path:** `Settings > TX Band Settings...` then select the **ATU Pre-Tune** tab.
+- **Alternative:** Right-click the Tuner applet in the Applet Panel and choose **ATU Pre-Tune** from the context menu.
+
+## What each control does
+
+| Control | Type | Behavior |
+|---|---|---|
+| **Band selection** | Combo box | Selects which HF/6m bands to include in the pre-tune sweep. Band edges follow the active region's band plan. |
+| **Start Sweep** | Push button | Begins the ATU pre-tune sweep. Steps through each selected band's center frequencies and triggers ATU tuning at each point. |
+
+## Troubleshooting
+
+- **Sweep does not start** — Ensure a radio is connected and the active TX slice exists. The dialog requires an active radio connection.
+- **ATU fails on some frequencies** — The radio's ATU may be unable to find a match on certain bands or antenna configurations. Verify your antenna is resonating reasonably on the chosen bands.
+
+## Related
+
+- [Radio Setup](Radio Setup)
+- [TX Band Settings](TX Band Settings)

--- a/docs/features/audio-device-change/overview.md
+++ b/docs/features/audio-device-change/overview.md
@@ -1,0 +1,28 @@
+# Audio Device Change overview
+
+The Audio Device Change feature automatically detects when system audio devices are added or removed while AetherSDR is running and prompts you to confirm or change the audio routing before audio breaks.
+
+## How it works
+
+AetherSDR monitors the system for audio device changes while running. When a device is added or removed — for example, when a USB audio interface is unplugged or replugged — the Audio Device Change dialog appears automatically. The dialog displays the current and available audio devices side-by-side so you can verify the routing or select a different device before audio is disrupted.
+
+The selected devices are persisted to AppSettings, so your choices are remembered for future sessions.
+
+## What each control does
+
+| Control | Behavior |
+|--------|----------|
+| **Available Input Devices** | Lists all detected input audio devices. The currently-selected device is highlighted. |
+| **Available Output Devices** | Lists all detected output audio devices. The currently-selected device is highlighted. |
+| **Apply** | Applies the selected audio devices and closes the dialog. Persists the choice to AppSettings. Styled as the primary action button. |
+| **Cancel** | Closes the dialog without changing audio devices. |
+
+## Tips
+
+- The dialog appears automatically — you don't need to open it manually. If you need to change audio devices at other times, use **Settings > Radio Setup...** and navigate to the audio configuration section.
+- Changes are saved to AppSettings immediately when you click **Apply**.
+
+## Troubleshooting
+
+- **The Audio Device Change dialog doesn't appear when I plug in a new USB audio device** — Ensure the device is properly connected and recognized by your operating system. Some devices may require driver installation before AetherSDR can detect them.
+- **Audio is lost after changing a device** — Click **Apply** to confirm the new device selection; the dialog will not apply changes until you explicitly do so.

--- a/docs/features/ax25-hf-packet-decode/overview.md
+++ b/docs/features/ax25-hf-packet-decode/overview.md
@@ -1,0 +1,31 @@
+# HF Packet Decode overview
+
+The HF Packet Decode feature decodes AX.25 amateur radio packet data transmitted over HF. It provides a real-time view of decoded frames, signal activity, and connection status for monitoring packet communications on the FLEX-8600. The decoder uses a shim layer over libmodem for physical-layer packet demodulation and integrates with the audio engine for live decode.
+
+## Before you start
+
+- Ensure AetherSDR is connected to a FLEX-8600 radio
+- The radio must be tuned to an active HF packet frequency
+
+## How it works
+
+HF Packet Decode pulls demodulated audio from the radio's audio stream and passes it through an AX.25 decoder. Decoded frames appear in a scrollable text area as they are received, showing source, destination, and payload information. A signal activity indicator provides real-time visual feedback of packet detection and decode status.
+
+The feature is opened from the digital modes area when HF packet decode is active, or from a related menu entry.
+
+## What each control does
+
+| Control | Kind | Behavior |
+|---------|------|----------|
+| Decoded frames | text_area | Scrollable display of decoded AX.25 frames showing source, destination, and payload information. New in v26.5.2.1. |
+| Signal activity | widget | Real-time signal activity indicator showing packet detection and decode status. Provided by PacketActivityWidget. |
+
+## Tips
+
+- The decoded frames area scrolls automatically as new frames are received. Use the scrollbar to review older frames.
+- For best decode results, tune the radio to a clear frequency with active HF packet activity. Typical HF packet frequencies are in the 14.100-14.110 MHz range on 20 meters and corresponding allocations on other bands.
+
+## Troubleshooting
+
+- **No frames decoded** — Verify the radio is connected and tuned to a frequency with active AX.25 packet activity. Check that the audio level is sufficient; the decoder needs a clean signal to demodulate.
+- **Garbled or partial frames** — Weak signals, interference, or incorrect tuning can cause decode errors. Try adjusting the receiver bandwidth or retuning to center the signal within the passband.

--- a/docs/features/dx-cluster-startup-commands/overview.md
+++ b/docs/features/dx-cluster-startup-commands/overview.md
@@ -1,0 +1,36 @@
+# DX Cluster Startup Commands overview
+
+Define custom commands that AetherSDR sends to a DX cluster or Reverse Beacon Network (RBN) immediately after each login and automatic reconnect. This lets you apply your preferred filter, announcements, or operational settings (e.g., `set/dx` or `set/wwv`) without manually typing them each time.
+
+## How it works
+
+When AetherSDR connects (or reconnects) to a DX cluster or RBN node, it sends every line in the corresponding command list, one per line, immediately after the login handshake completes. The same commands are replayed after every automatic reconnection triggered by a network drop.
+
+Two independent command sets are stored and managed:
+
+- **DX Cluster** — commands sent to the cluster configured on the DX Cluster tab in SpotHub (`DxClusterStartupCommands` AppSettings key).
+- **RBN** — commands sent to the Reverse Beacon Network tab in SpotHub (`RbnStartupCommands` AppSettings key).
+
+## What each control does
+
+| Control | Default | Valid range / Notes | AppSettings key |
+|---|---|---|---|
+| **Command editor** (multi-line plain text editor) | *(empty)* | One command per line. Blank lines are ignored. No limit on number of lines. | `DxClusterStartupCommands` (main tab) / `RbnStartupCommands` (RBN tab) |
+
+## Opening the dialog
+
+Open `Settings > SpotHub...`, then click **Edit Startup Commands** on either:
+
+- The **DX Cluster** tab — to edit the main cluster command set.
+- The **RBN** tab — to edit the RBN command set.
+
+## Tips
+
+- Commands are sent in the order they appear in the editor, top to bottom.
+- Typical startup commands include `set/dx` (enable DX spots), `set/announce` (enable announcements), or `set/filter` to limit spot types. Check your cluster's help (`help`) for available commands.
+- If a command requires a response from the cluster (e.g., a status confirmation), AetherSDR does not wait — it sends all lines immediately. For time-sensitive sequences, keep them short.
+- Changes take effect on the next connection or reconnect; they are not sent to an already-connected session.
+
+## See also
+
+- [DX Cluster & RBN configuration](dx-cluster-rbn-configuration.md)

--- a/docs/features/profile-import-export/overview.md
+++ b/docs/features/profile-import-export/overview.md
@@ -1,0 +1,39 @@
+# Profile Import/Export overview
+
+The Profile Import/Export feature lets you save radio profiles (Global, Transmit, and Microphone) to files on your local machine and restore them later. This is useful for backing up your radio configuration, transferring settings between radios, or sharing profiles with other operators.
+
+## Before you start
+
+- A radio connection is required to export profiles from or import profiles to the radio.
+- The feature requires AetherSDR v26.5.2.1 or later.
+
+## How it works
+
+The Profile Import/Export dialog has two tabs: **Export** and **Import**.
+
+### Export tab
+
+1. Open the dialog: **Profiles > Import/Export Profiles...**
+2. Click the **Export** tab if not already selected.
+3. Select the checkboxes next to the profiles you want to export.
+4. Choose a file path using the file path chooser.
+5. Click **Export** to save the selected profiles to the chosen file.
+
+### Import tab
+
+1. Open the dialog: **Profiles > Import/Export Profiles...**
+2. Click the **Import** tab.
+3. Browse for the profile file on your local machine — available files are shown.
+4. Select which profiles to restore using the checkboxes.
+5. Click **Import** to push the selected profiles to the radio.
+
+## What each control does
+
+| Control | Kind | Behavior | Notes |
+|---------|------|----------|-------|
+| **Export** (tab) | tab | Shows a list of radio profiles with checkboxes for selection and a file path chooser. Clicking **Export** saves the selected profiles to the chosen file. | New in v26.5.2.1. |
+| **Import** (tab) | tab | Shows available profile files on the local machine. Select which profiles to restore and click **Import** to push them to the radio. | — |
+
+## Related
+
+- [Profile Manager](profile-manager.md) — view, create, edit, and delete transmit profiles

--- a/docs/features/tx-band/overview.md
+++ b/docs/features/tx-band/overview.md
@@ -1,0 +1,40 @@
+# TX Band Settings overview
+
+The TX Band Settings dialog lets you view and configure per-band transmit parameters on your FLEX-8600, including power limits, tune power, inhibit settings, and external amplifier control. Use this page to tailor TX behavior for each amateur radio band.
+
+## Before you start
+
+- A FLEX-8600 radio must be connected and powered on.
+- The application must have an active radio connection.
+
+## How it works
+
+The TX Band Settings dialog opens a tabbed interface showing one tab per band. Each tab contains transmit configuration controls specific to that band:
+
+- **Power limits** – Set the maximum power output (in watts) for the selected band. Adjustable from 0 W up to the radio’s maximum.
+- **Tune power** – Set the power level used during tune operations. Typically lower than the main power limit to avoid overdriving the antenna.
+- **Band enable/disable** – Toggle whether the band is available for transmit. Disabling a band prevents accidental transmission outside allowed frequencies.
+- **Inhibit settings** – Control which TX outputs (ACC TX, TX1, TX2, TX3) are suppressed during tuning. Configured via the menu `Settings > Inhibit during TUNE`.
+- **External amplifier control** – Configure relay and keying outputs for external amplifiers per band.
+
+The dialog is also accessible from the main menu: **`Settings > TX Band Settings...`**
+
+## What each control does
+
+| Control | Purpose | Default | Valid range | Setting key |
+|---|---|---|---|---|
+| Per-band settings (tab) | Shows transmit configuration for a single band, including power limits, enable/disable toggles, and inhibit options. | (none) | (varies by control inside tab) | (none) |
+| Band Enable checkbox | Enables or disables TX on the selected band. Unchecked = TX inhibited. | (enabled) | On/Off | (per-band key internal to radio) |
+| Power Limit slider/input | Sets maximum TX power for the band. | (varies by band) | 0 – radio max (W) | (per-band key internal to radio) |
+| Tune Power slider/input | Sets power used during tuning. | (varies) | 0 – radio max (W) | (per-band key internal to radio) |
+
+## Tips
+
+- Use band enable/disable to prevent accidental transmission on bands where you don’t have a license or antenna.
+- The **Inhibit during TUNE** menu lets you suppress specific TX outputs (ACC TX, TX1, TX2, TX3) while tuning — useful to avoid keying an amplifier during tune cycles.
+- Changes made in the TX Band Settings are sent directly to the radio; no separate “Save” button is needed.
+
+## Related
+
+- [Radio Setup...](radio-setup-dialog.md)
+- [Inhibit during TUNE](inhibit-during-tune.md)

--- a/docs/features/waveforms/overview.md
+++ b/docs/features/waveforms/overview.md
@@ -1,0 +1,32 @@
+# Waveforms overview
+
+The Waveforms dialog mirrors the SmartSDR File > Waveforms panel, letting you view the WFP (Waveform Processor) status and manage installed waveforms on your FLEX-8600 radio. Use it to check whether the waveform processor is powered and ready, see its IP address, and restart or remove individual waveforms.
+
+## How it works
+
+The dialog connects directly to the radio's FlexWaveformModel for live status updates. It shows WFP power state, readiness, and IP address at the top, followed by a list of installed waveforms with per-row controls.
+
+## What each control does
+
+| Control | Behavior | Notes |
+|---|---|---|
+| **WFP Status** | Displays waveform processor power status, ready state, and IP address. | New in v26.5.2.1. |
+| **Installed Waveforms** | Lists installed waveforms with **Restart** and **Remove/Uninstall** buttons per row. | Connects to FlexWaveformModel for live status. |
+
+## How to open
+
+**File > Waveforms...**
+
+## Requirements
+
+- A radio connection must be active (the dialog requires radio connectivity).
+
+## Tips
+
+- The dialog is non-modal, so you can keep it open while operating the radio.
+- Use the **Restart** button to reload a waveform without removing and reinstalling it.
+- Use **Remove/Uninstall** to delete an unwanted waveform from the radio.
+
+## Related
+
+- [Radio Setup...](radio-setup.md) — Configure radio connection, audio, antenna, and band settings.


### PR DESCRIPTION
## Summary

- 7 new user-facing dialogs from the v26.5.2.1 catalog update now have documentation pages
- New entries: ATU Pre-Tune, Audio Device Change, AX.25 HF Packet Decode,
  DX Cluster Startup Commands, Profile Import/Export, TX Band, Waveforms
- Each page covers overview, usage steps, and settings
- Generated via pipeline (build_topics.py → generate_docs.py) with DeepSeek-V3

## Test plan

- [ ] Verify each new page renders correctly in mkdocs serve
- [ ] Check navigation auto-discovers new entries (awesome-pages plugin)
- [ ] Confirm links to related pages work

🤖 Generated with [Claude Code](https://claude.com/claude-code)