### PR TITLE
docs: update v26.5.2.1 changelog — 9 new pages

### DIFF
--- a/docs/changelog/v26.5.2.1.md
+++ b/docs/changelog/v26.5.2.1.md
@@ -4,7 +4,7 @@ Documentation changes accompanying the **AetherSDR v26.5.2.1** release.
 
 **Date:** 2026-05-17
 
-**Total:** 293 files (2 new + 291 updated)
+**Total:** 300 files (9 new + 291 updated)
 
 | Section | File | Status | Date |
 |---|---|---|---|
@@ -21,6 +21,9 @@ Documentation changes accompanying the **AetherSDR v26.5.2.1** release.
 | aether-dsp | [`switch-nr2-gain-method-between-linear-log-gamma-and-trained.md`](../features/aether-dsp/switch-nr2-gain-method-between-linear-log-gamma-and-trained.md) | Updated | 2026-05-17 |
 | aether-dsp | [`tune-nr2-reduction-depth-and-voice-threshold.md`](../features/aether-dsp/tune-nr2-reduction-depth-and-voice-threshold.md) | Updated | 2026-05-17 |
 | aether-dsp | [`tune-nr4-masking-depth-and-suppression-strength.md`](../features/aether-dsp/tune-nr4-masking-depth-and-suppression-strength.md) | Updated | 2026-05-17 |
+| atu-pre-tune | [`overview.md`](../features/atu-pre-tune/overview.md) | Created | 2026-05-17 |
+| audio-device-change | [`overview.md`](../features/audio-device-change/overview.md) | Created | 2026-05-17 |
+| ax25-hf-packet-decode | [`overview.md`](../features/ax25-hf-packet-decode/overview.md) | Created | 2026-05-17 |
 | client-comp | [`adjust-compressor-threshold-tx-or-rx-side.md`](../features/client-comp/adjust-compressor-threshold-tx-or-rx-side.md) | Updated | 2026-05-17 |
 | client-comp | [`apply-make-up-gain-after-compression.md`](../features/client-comp/apply-make-up-gain-after-compression.md) | Updated | 2026-05-17 |
 | client-comp | [`bypass-the-compressor-from-the-chain.md`](../features/client-comp/bypass-the-compressor-from-the-chain.md) | Updated | 2026-05-17 |
@@ -133,6 +136,7 @@ Documentation changes accompanying the **AetherSDR v26.5.2.1** release.
 | dx-cluster | [`toggle-signal-history-voice-markers-on-the-panadapter.md`](../features/dx-cluster/toggle-signal-history-voice-markers-on-the-panadapter.md) | Updated | 2026-05-17 |
 | dx-cluster | [`tune-spot-density-position-font-size-and-lifetime.md`](../features/dx-cluster/tune-spot-density-position-font-size-and-lifetime.md) | Updated | 2026-05-17 |
 | dx-cluster | [`tune-to-a-spot-by-double-clicking-the-spot-list.md`](../features/dx-cluster/tune-to-a-spot-by-double-clicking-the-spot-list.md) | Updated | 2026-05-17 |
+| dx-cluster-startup-commands | [`overview.md`](../features/dx-cluster-startup-commands/overview.md) | Created | 2026-05-17 |
 | eq | [`boost-or-cut-specific-octave-bands-63-hz-to-8-khz.md`](../features/eq/boost-or-cut-specific-octave-bands-63-hz-to-8-khz.md) | Updated | 2026-05-17 |
 | eq | [`compare-eq-on-vs-eq-off-quickly-with-the-on-button.md`](../features/eq/compare-eq-on-vs-eq-off-quickly-with-the-on-button.md) | Updated | 2026-05-17 |
 | eq | [`enable-radio-side-graphic-eq-for-rx.md`](../features/eq/enable-radio-side-graphic-eq-for-rx.md) | Updated | 2026-05-17 |
@@ -194,6 +198,7 @@ Documentation changes accompanying the **AetherSDR v26.5.2.1** release.
 | profile-manager | [`save-the-current-radio-state-as-a-new-global-profile.md`](../features/profile-manager/save-the-current-radio-state-as-a-new-global-profile.md) | Updated | 2026-05-17 |
 | profile-manager | [`switch-to-a-saved-transmit-profile.md`](../features/profile-manager/switch-to-a-saved-transmit-profile.md) | Updated | 2026-05-17 |
 | profile-manager | [`turn-on-auto-save-so-tx-tweaks-always-persist.md`](../features/profile-manager/turn-on-auto-save-so-tx-tweaks-always-persist.md) | Updated | 2026-05-17 |
+| profile-import-export | [`overview.md`](../features/profile-import-export/overview.md) | Created | 2026-05-17 |
 | prop-dashboard | [`check-current-solar-flux-sunspot-number-and-k-index.md`](../features/prop-dashboard/check-current-solar-flux-sunspot-number-and-k-index.md) | Updated | 2026-05-17 |
 | prop-dashboard | [`cycle-solar-imagery-wavelengths-to-build-intuition.md`](../features/prop-dashboard/cycle-solar-imagery-wavelengths-to-build-intuition.md) | Updated | 2026-05-17 |
 | prop-dashboard | [`decide-which-hf-band-is-open-for-day-or-night-work.md`](../features/prop-dashboard/decide-which-hf-band-is-open-for-day-or-night-work.md) | Updated | 2026-05-17 |
@@ -274,6 +279,7 @@ Documentation changes accompanying the **AetherSDR v26.5.2.1** release.
 | tx | [`start-a-tune-carrier-to-check-swr.md`](../features/tx/start-a-tune-carrier-to-check-swr.md) | Updated | 2026-05-17 |
 | tx | [`switch-tx-profiles-e-g-ssb-digital.md`](../features/tx/switch-tx-profiles-e-g-ssb-digital.md) | Updated | 2026-05-17 |
 | tx | [`toggle-mox-to-manually-key-the-transmitter.md`](../features/tx/toggle-mox-to-manually-key-the-transmitter.md) | Updated | 2026-05-17 |
+| tx-band | [`overview.md`](../features/tx-band/overview.md) | Created | 2026-05-17 |
 | vfo-widget | [`adjust-af-gain-and-pan-from-the-vfo-panel.md`](../features/vfo-widget/adjust-af-gain-and-pan-from-the-vfo-panel.md) | Updated | 2026-05-17 |
 | vfo-widget | [`apply-a-filter-width-preset-from-the-vfo-panel.md`](../features/vfo-widget/apply-a-filter-width-preset-from-the-vfo-panel.md) | Updated | 2026-05-17 |
 | vfo-widget | [`assign-a-dax-channel-from-the-vfo-panel.md`](../features/vfo-widget/assign-a-dax-channel-from-the-vfo-panel.md) | Updated | 2026-05-17 |
@@ -296,6 +302,7 @@ Documentation changes accompanying the **AetherSDR v26.5.2.1** release.
 | wave | [`pause-the-waveform-to-inspect-a-transient.md`](../features/wave/pause-the-waveform-to-inspect-a-transient.md) | Updated | 2026-05-17 |
 | wave | [`set-the-waveform-refresh-rate-to-reduce-cpu-load.md`](../features/wave/set-the-waveform-refresh-rate-to-reduce-cpu-load.md) | Updated | 2026-05-17 |
 | wave | [`switch-the-waveform-view-mode-scope-envelope-history-bands.md`](../features/wave/switch-the-waveform-view-mode-scope-envelope-history-bands.md) | Updated | 2026-05-17 |
+| waveforms | [`overview.md`](../features/waveforms/overview.md) | Created | 2026-05-17 |
 | whats-new | [`open-the-upgrade-flow-for-a-newer-build.md`](../features/whats-new/open-the-upgrade-flow-for-a-newer-build.md) | Updated | 2026-05-17 |
 | whats-new | [`overview.md`](../features/whats-new/overview.md) | Updated | 2026-05-17 |
 | whats-new | [`re-read-release-notes-later-via-help-menu.md`](../features/whats-new/re-read-release-notes-later-via-help-menu.md) | Updated | 2026-05-17 |


### PR DESCRIPTION
## Summary

The changelog for v26.5.2.1 still showed "2 new" pages (from the first pipeline run).
After the second pass added 7 new feature pages, this updates the count to "9 new"
and adds the corresponding table entries.

## Changes
- Total: 293→300 files (9 new + 291 updated)
- Added 7 rows: atu-pre-tune, audio-device-change, ax25-hf-packet-decode,
  dx-cluster-startup-commands, profile-import-export, tx-band, waveforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)